### PR TITLE
Transform api operations based upon middleware wrappers

### DIFF
--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -39,7 +39,7 @@ mod template {
         ",
         );
         contents.push_str(&name);
-        contents.push_str(",");
+        contents.push(',');
     }
 
     contents.push_str(


### PR DESCRIPTION
I came across the need to modify the api spec based on properties of middleware transformers. In our case it was RBAC middleware which specified different roles for different endpoints.

This change adds another trait to the parameter on the `Resource` wrapper, `TransformApi`. In this use case it allowed the roles required on the endpoints to be automatically added to `operation.tags` and into `operation.description`, which seems like it will be very useful.

I have a couple of concerns about it though:
* this changes the signature of `wrap` so it is a breaking change for users of that function - it could be given a new name
* I've made `RouteWrapper` public - maybe it should use a different type?
* the transformers need to be cloned to be passed into the inner and kept in the wrapper - but in my case they are very small
* the transformers are being kept in the wrapper in a type-system linked list, this avoided allocations and is fine in my case but maybe others would have a problem with it
