### PR TITLE
feat(error responses): error responses definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for the `#[serde(skip)]` attribute in structs and enums.
 
 ### Changed
+- Actix plugin: `#[api_v2_errors]` macro now supports adding different error schemes per response code.
 
 ### Fixed
 - Optional type aliases like `type Email = Option<String>` will not be added to the `required` fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Actix plugin: `#[api_v2_errors]` macro now supports adding different error schemes per response code.
+- Actix plugin: Add new `#[api_v2_errors_overlay]` macro which can be used to filter out unwanted responses from an existing error type.
 
 ### Fixed
 - Optional type aliases like `type Email = Option<String>` will not be added to the `required` fields.

--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -2,8 +2,8 @@
 use super::schema::TypedData;
 use super::{
     models::{
-        DefaultOperationRaw, DefaultResponseRaw, DefaultSchemaRaw, Either, Items, Parameter,
-        ParameterIn, Response, SecurityScheme,
+        DefaultOperationRaw, DefaultSchemaRaw, Either, Items, Parameter, ParameterIn, Response,
+        SecurityScheme,
     },
     schema::{Apiv2Errors, Apiv2Operation, Apiv2Schema},
 };
@@ -133,11 +133,12 @@ where
 
     fn update_response(op: &mut DefaultOperationRaw) {
         T::update_response(op);
-        update_error_definitions_from_schema_type::<E>(op);
+        E::update_error_definitions(op);
     }
 
     fn update_definitions(map: &mut BTreeMap<String, DefaultSchemaRaw>) {
         T::update_definitions(map);
+        E::update_definitions(map);
     }
 
     fn update_security_definitions(map: &mut BTreeMap<String, SecurityScheme>) {
@@ -529,22 +530,6 @@ where
         }
 
         break;
-    }
-}
-
-/// Given a schema type that represents an error, add the responses
-/// representing those errors.
-fn update_error_definitions_from_schema_type<T>(op: &mut DefaultOperationRaw)
-where
-    T: Apiv2Errors,
-{
-    for (status, def_name) in T::ERROR_MAP {
-        let response = DefaultResponseRaw {
-            description: Some((*def_name).to_string()),
-            ..Default::default()
-        };
-        op.responses
-            .insert(status.to_string(), Either::Right(response));
     }
 }
 

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -478,6 +478,8 @@ pub trait Apiv2Operation {
 /// - [`paperclip_actix::api_v2_errors`](https://paperclip.waffles.space/paperclip_actix/attr.api_v2_errors.html).
 pub trait Apiv2Errors {
     const ERROR_MAP: &'static [(u16, &'static str)] = &[];
+    fn update_error_definitions(_op: &mut DefaultOperationRaw) {}
+    fn update_definitions(_map: &mut BTreeMap<String, DefaultSchemaRaw>) {}
 }
 
 impl Apiv2Errors for () {}

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -16,6 +16,7 @@ use syn::{
     ReturnType, Token, TraitBound, Type, TypeTraitObject,
 };
 
+use proc_macro2::TokenStream as TokenStream2;
 use std::collections::HashMap;
 
 const SCHEMA_MACRO_ATTR: &str = "openapi";
@@ -364,25 +365,25 @@ pub fn emit_v2_errors(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let generics = item_ast.generics.clone();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    // Convert macro attributes to tuples in form of (u16, &str)
+    let mut default_schema: Option<syn::Ident> = None;
+    // Convert macro attributes to tuples in form of (u16, &str, &Option<syn::Ident>)
     let error_codes = attrs
         .0
         .iter()
         // Pair code attrs with description attrs; save attr itself to properly span error messages at later stage
-        .fold(Vec::new(), |mut list: Vec<(Option<u16>, Option<String>, _)>, attr| {
+        .fold(Vec::new(), |mut list: Vec<(Option<u16>, Option<String>, Option<syn::Ident>, _)>, attr| {
             let span = attr.span().unwrap();
             match attr {
                 // Read named attribute.
                 NestedMeta::Meta(Meta::NameValue(name_value)) => {
                     let attr_name = name_value.path.get_ident().map(|ident| ident.to_string());
                     let attr_value = &name_value.lit;
-
                     match (attr_name.as_deref(), attr_value) {
                         // "code" attribute adds new element to list
                         (Some("code"), Lit::Int(attr_value)) => {
                             let status_code = attr_value.base10_parse::<u16>()
                                 .map_err(|_| emit_error!(span, "Invalid u16 in code argument")).ok();
-                            list.push((status_code, None, attr));
+                            list.push((status_code, None, None, attr));
                         },
                         // "description" attribute updates last element in list
                         (Some("description"), Lit::Str(attr_value)) =>
@@ -394,26 +395,46 @@ pub fn emit_v2_errors(attrs: TokenStream, input: TokenStream) -> TokenStream {
                             } else {
                                 emit_error!(span, "Attribute 'description' can be only placed after prior 'code' argument");
                             },
-                        _ => emit_error!(span, "Invalid macro attribute. Should be plain u16, 'code = u16' or 'description = str'")
+                        // "schema" attribute updates last element in list
+                        (Some("schema"), Lit::Str(attr_value)) =>
+                            if let Some(last_value) = list.last_mut() {
+                                if last_value.2.is_some() {
+                                    emit_warning!(span, "This attribute overwrites previous schema");
+                                }
+                                match attr_value.parse() {
+                                    Ok(value) => last_value.2 = Some(value),
+                                    Err(error) => emit_error!(span, "Error parsing schema: {}", error),
+                                }
+                            } else {
+                                emit_error!(span, "Attribute 'schema' can be only placed after prior 'code' argument");
+                            },
+                        (Some("default_schema"), Lit::Str(attr_value)) =>
+                            match attr_value.parse() {
+                                Ok(value) => default_schema = Some(value),
+                                Err(error) => emit_error!(span, "Error parsing default_schema: {}", error),
+                            },
+                        _ => emit_error!(span, "Invalid macro attribute. Should be plain u16, 'code = u16', 'description = str', 'schema = str' or 'default_schema = str'")
                     }
                 },
                 // Read plain status code as attribute.
                 NestedMeta::Lit(Lit::Int(attr_value)) => {
                     let status_code = attr_value.base10_parse::<u16>()
                     .map_err(|_| emit_error!(span, "Invalid u16 in code argument")).ok();
-                    list.push((status_code, None, attr));
+                    list.push((status_code, None, None, attr));
                 },
-                _ => emit_error!(span, "This macro supports only named attributes - 'code' (u16) or 'description' (str)")
+                _ => emit_error!(span, "This macro supports only named attributes - 'code' (u16), 'description' (str), 'schema' (str) or 'default_schema' (str)")
             }
 
             list
         })
         .iter()
         // Map code-message pairs into bits of code, filter empty codes out
-        .filter_map(|triple| {
-            let (code, description) = match triple {
-                (Some(code), Some(description), _) => (code, description.to_owned()),
-                (Some(code), None, attr) => {
+        .filter_map(|quad| {
+            let (code, description, schema) = match quad {
+                (Some(code), Some(description), schema, _) => {
+                    (code, description.to_owned(), schema.to_owned())
+                },
+                (Some(code), None, schema, attr) => {
                     let span = attr.span().unwrap();
                     let description = StatusCode::from_u16(*code)
                         .map_err(|_| {
@@ -428,27 +449,106 @@ pub fn emit_v2_errors(attrs: TokenStream, input: TokenStream) -> TokenStream {
                             })
                         )
                         .unwrap_or_else(|_| String::new());
-                    (code, description)
+                    (code, description, schema.to_owned())
                 },
-                (None, _, _) => return None,
+                (None, _, _, _) => return None,
             };
-
-            Some(quote! {
-                (#code, #description),
-            })
+            Some((*code, description, schema))
         })
-        .fold(proc_macro2::TokenStream::new(), |mut stream, tokens| {
+        .collect::<Vec<(u16, String, Option<syn::Ident>)>>();
+
+    let error_definitions = error_codes.iter().fold(
+        if default_schema.is_none() {
+            TokenStream2::new()
+        } else {
+            quote! {
+                #default_schema::update_definitions(map);
+            }
+        },
+        |mut stream, (_, _, schema)| {
+            if let Some(schema) = schema {
+                let tokens = quote! {
+                    #schema::update_definitions(map);
+                };
+                stream.extend(tokens);
+            }
+            stream
+        },
+    );
+
+    let update_definitions = quote! {
+        fn update_definitions(map: &mut std::collections::BTreeMap<String, paperclip::v2::models::DefaultSchemaRaw>) {
+            use paperclip::actix::OperationModifier;
+            #error_definitions
+        }
+    };
+
+    // for compatibility with previous error trait
+    let error_map = error_codes.iter().fold(
+        proc_macro2::TokenStream::new(),
+        |mut stream, (code, description, _)| {
+            let token = quote! {
+                (#code, #description),
+            };
+            stream.extend(token);
+            stream
+        },
+    );
+
+    let update_error_helper = quote! {
+        fn update_error_definitions(code: &u16, description: &str, schema: &Option<&str>, op: &mut paperclip::v2::models::DefaultOperationRaw) {
+            if let Some(schema) = &schema {
+                op.responses.insert(code.to_string(), paperclip::v2::models::Either::Right(paperclip::v2::models::Response {
+                    description: Some(description.to_string()),
+                    schema: Some(paperclip::v2::models::DefaultSchemaRaw {
+                        name: Some(schema.to_string()),
+                        reference: Some(format!("#/definitions/{}", schema)),
+                        .. Default::default()
+                    }),
+                    ..Default::default()
+                }));
+            } else {
+                op.responses.insert(code.to_string(), paperclip::v2::models::Either::Right(paperclip::v2::models::DefaultResponseRaw {
+                    description: Some(description.to_string()),
+                    ..Default::default()
+                }));
+            }
+        }
+    };
+    let default_schema = default_schema.map(|i| i.to_string());
+    let update_errors = error_codes.iter().fold(
+        update_error_helper,
+        |mut stream, (code, description, schema)| {
+            let tokens = if let Some(schema) = schema {
+                let schema = schema.to_string();
+                quote! {
+                    update_error_definitions(&#code, #description, &Some(#schema), op);
+                }
+            } else if let Some(scheme) = &default_schema {
+                quote! {
+                    update_error_definitions(&#code, #description, &Some(#scheme), op);
+                }
+            } else {
+                quote! {
+                    update_error_definitions(&#code, #description, &None, op);
+                }
+            };
             stream.extend(tokens);
             stream
-        });
+        },
+    );
 
     let gen = quote! {
         #item_ast
 
         impl #impl_generics paperclip::v2::schema::Apiv2Errors for #name #ty_generics #where_clause {
             const ERROR_MAP: &'static [(u16, &'static str)] = &[
-                #error_codes
+                #error_map
             ];
+            fn update_error_definitions(op: &mut paperclip::v2::models::DefaultOperationRaw) {
+                #update_errors
+            }
+            #update_definitions
         }
     };
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -68,6 +68,15 @@ pub fn api_v2_errors(attrs: TokenStream, input: TokenStream) -> TokenStream {
     self::actix::emit_v2_errors(attrs, input)
 }
 
+/// Marker attribute for indicating that the marked object can filter error responses from the
+/// the `#[api_v2_errors]` macro.
+#[cfg(feature = "actix")]
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn api_v2_errors_overlay(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    self::actix::emit_v2_errors_overlay(attrs, input)
+}
+
 /// Generate an error at the call site and return empty token stream.
 #[allow(dead_code)]
 fn span_error_with_msg<T: Spanned>(it: &T, msg: &str) -> TokenStream {

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -7,7 +7,8 @@ pub mod web;
 
 pub use self::web::{Resource, Route, Scope};
 pub use paperclip_macros::{
-    api_v2_errors, api_v2_operation, delete, get, post, put, Apiv2Schema, Apiv2Security,
+    api_v2_errors, api_v2_errors_overlay, api_v2_operation, delete, get, post, put, Apiv2Schema,
+    Apiv2Security,
 };
 
 use self::web::{RouteWrapper, ServiceConfig};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ pub mod actix {
     //! Plugin types, traits and macros for actix-web framework.
 
     pub use paperclip_actix::{
-        api_v2_errors, api_v2_operation, delete, get, post, put, web, Apiv2Schema, Apiv2Security,
-        App, Mountable, OpenApiExt,
+        api_v2_errors, api_v2_errors_overlay, api_v2_operation, delete, get, post, put, web,
+        Apiv2Schema, Apiv2Security, App, Mountable, OpenApiExt,
     };
     pub use paperclip_core::v2::{
         AcceptedJson, CreatedJson, NoContent, OperationModifier, ResponderWrapper, ResponseWrapper,

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -2469,18 +2469,47 @@ fn test_errors_app() {
     };
     use std::fmt;
 
+    #[derive(Debug, Serialize, Deserialize, Apiv2Schema)]
+    struct PetErrorScheme1 {}
+    #[derive(Debug, Serialize, Deserialize, Apiv2Schema)]
+    struct PetErrorScheme2 {}
+    #[derive(Debug, Serialize, Deserialize, Apiv2Schema)]
+    struct PetErrorScheme3 {}
+
     #[api_v2_errors(
         400,
         description = "Sorry, bad request",
         code = 401,
         code = 403,
+        schema = "PetErrorScheme1",
         description = "Forbidden, go away",
-        500
+        500,
+        description = "Internal Server Error",
+        schema = "PetErrorScheme2"
     )]
     #[derive(Debug)]
     struct PetError {}
 
+    #[api_v2_errors(
+        400,
+        description = "Sorry, bad request",
+        code = 401,
+        code = 403,
+        schema = "PetErrorScheme1",
+        description = "Forbidden, go away",
+        500,
+        description = "Internal Server Error",
+        default_schema = "PetErrorScheme2"
+    )]
+    #[derive(Debug)]
+    struct PetError2 {}
+
     impl fmt::Display for PetError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Bad Request")
+        }
+    }
+    impl fmt::Display for PetError2 {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "Bad Request")
         }
@@ -2491,14 +2520,25 @@ fn test_errors_app() {
             HttpResponse::from_error(ErrorBadRequest("Bad Request"))
         }
     }
+    impl ResponseError for PetError2 {
+        fn error_response(&self) -> HttpResponse {
+            HttpResponse::from_error(ErrorBadRequest("Bad Request"))
+        }
+    }
 
     #[api_v2_operation]
     async fn echo_pet_with_errors(body: web::Json<Pet>) -> Result<web::Json<Pet>, PetError> {
         Ok(body)
     }
 
+    #[api_v2_operation]
+    async fn echo_pet_with_errors2(body: web::Json<Pet>) -> Result<web::Json<Pet>, PetError2> {
+        Ok(body)
+    }
+
     fn config(cfg: &mut web::ServiceConfig) {
         cfg.service(web::resource("/echo").route(web::post().to(echo_pet_with_errors)));
+        cfg.service(web::resource("/echo2").route(web::post().to(echo_pet_with_errors2)));
     }
 
     run_and_check_app(
@@ -2550,7 +2590,13 @@ fn test_errors_app() {
                       },
                       "required":["birthday", "class", "name"],
                       "type":"object"
-                    }
+                    },
+                    "PetErrorScheme1": {
+                      "type": "object"
+                    },
+                    "PetErrorScheme2": {
+                      "type": "object"
+                    },
                   },
                   "paths": {
                     "/api/echo": {
@@ -2577,10 +2623,60 @@ fn test_errors_app() {
                             "description": "Unauthorized"
                           },
                           "403":{
-                            "description":"Forbidden, go away"
+                            "description": "Forbidden, go away",
+                            "schema": {
+                              "$ref": "#/definitions/PetErrorScheme1"
+                            }
                           },
                           "500": {
-                            "description": "Internal Server Error"
+                            "description": "Internal Server Error",
+                            "schema": {
+                              "$ref": "#/definitions/PetErrorScheme2"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "/api/echo2": {
+                      "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
+                        "responses": {
+                          "200": {
+                            "description": "OK",
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          },
+                          "400": {
+                            "description": "Sorry, bad request",
+                            "schema": {
+                              "$ref": "#/definitions/PetErrorScheme2"
+                            }
+                          },
+                          "401": {
+                            "description": "Unauthorized",
+                            "schema": {
+                              "$ref": "#/definitions/PetErrorScheme2"
+                            }
+                          },
+                          "403":{
+                            "description": "Forbidden, go away",
+                            "schema": {
+                              "$ref": "#/definitions/PetErrorScheme1"
+                            }
+                          },
+                          "500": {
+                            "description": "Internal Server Error",
+                            "schema": {
+                              "$ref": "#/definitions/PetErrorScheme2"
+                            }
                           }
                         }
                       }
@@ -2606,8 +2702,8 @@ fn test_security_app() {
     struct AccessToken;
 
     impl FromRequest for AccessToken {
-        type Future = Ready<Result<Self, Self::Error>>;
         type Error = Error;
+        type Future = Ready<Result<Self, Self::Error>>;
         type Config = ();
 
         fn from_request(_: &HttpRequest, _payload: &mut actix_web::dev::Payload) -> Self::Future {
@@ -2626,8 +2722,8 @@ fn test_security_app() {
     struct OAuth2Access;
 
     impl FromRequest for OAuth2Access {
-        type Future = Ready<Result<Self, Self::Error>>;
         type Error = Error;
+        type Future = Ready<Result<Self, Self::Error>>;
         type Config = ();
 
         fn from_request(_: &HttpRequest, _payload: &mut actix_web::dev::Payload) -> Self::Future {
@@ -2640,8 +2736,8 @@ fn test_security_app() {
     struct PetScope;
 
     impl FromRequest for PetScope {
-        type Future = Ready<Result<Self, Self::Error>>;
         type Error = Error;
+        type Future = Ready<Result<Self, Self::Error>>;
         type Config = ();
 
         fn from_request(_: &HttpRequest, _payload: &mut actix_web::dev::Payload) -> Self::Future {


### PR DESCRIPTION
Ability to specify an error type schema to an error response, either to
 each specific error code or a common for all.
Add error overlay over an existing Apiv2Error which allows us to filter
 out errors from the existing type which may not suit a particular
 URI handler.
Closes #306 