### PR TITLE
Update `paperclip` dependency from `0.4` to `0.5` in book

### DIFF
--- a/book/actix-plugin.md
+++ b/book/actix-plugin.md
@@ -14,7 +14,7 @@ actix-web = "3.0"
 # this plugin works smoothly with the nightly compiler, it also works in stable
 # channel (replace "actix-nightly" feature with "actix" in that case). There maybe compilation errors,
 # but those can be fixed.
-paperclip = { version = "0.4", features = ["actix-nightly"] }
+paperclip = { version = "0.5", features = ["actix-nightly"] }
 serde = "1.0"
 ```
 


### PR DESCRIPTION
A compile error occurred when building with `paperclip-0.4`, but the example could build successfully with `paperclip-0.5`.

```
error[E0599]: no method named `wrap_api` found for struct `actix_web::App<actix_web::app_service::AppEntry, actix_web::dev::Body>` in the current scope
  --> src/main.rs:33:10
   |
33 |         .wrap_api()
   |          ^^^^^^^^ method not found in `actix_web::App<actix_web::app_service::AppEntry, actix_web::dev::Body>`

warning: unused import: `OpenApiExt`
  --> src/main.rs:11:33
   |
11 |         CreatedJson, NoContent, OpenApiExt,
   |                                 ^^^^^^^^^^
```