### PR TITLE
[Actix plugin] Add random prefix to definition in API spec 

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -22,6 +22,7 @@ heck = { version = "0.3", optional = true }
 http = { version = "0.2", optional = true }
 lazy_static = { version = "1.4", optional = true }
 strum = { version = "0.22", optional = true }
+rand = "0.8"
 strum_macros = { version = "0.22", optional = true }
 
 [features]

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -6,6 +6,7 @@ use http::StatusCode;
 use lazy_static::lazy_static;
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
+use rand::Rng;
 use strum_macros::EnumString;
 use syn::{
     parse_macro_input,
@@ -15,7 +16,6 @@ use syn::{
     Generics, Ident, ItemFn, Lit, Meta, MetaList, MetaNameValue, NestedMeta, Path, PathArguments,
     ReturnType, Token, TraitBound, Type, TypeTraitObject,
 };
-use rand::Rng;
 
 use proc_macro2::TokenStream as TokenStream2;
 use std::collections::HashMap;


### PR DESCRIPTION
This PR adds a 6 character (A-Z) prefix to every generated definition (the `Apiv2Schema` proc macro). The reason for this PR is described in #357, this PR solves #357 too.

Feedback is highly appreciated!