### PR TITLE
Fix favicons for swagger-ui and add simple error handling

### DIFF
--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -383,9 +383,8 @@ where
                             HttpResponse::Ok().body(
                                 SWAGGER_DIST
                                     .get_file(filename)
-                                    .unwrap()
-                                    .contents_utf8()
-                                    .unwrap(),
+                                    .expect(&format!("Failed to get file {}",filename))
+                                    .contents(),
                             )
                         }
                     }),

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -383,7 +383,7 @@ where
                             HttpResponse::Ok().body(
                                 SWAGGER_DIST
                                     .get_file(filename)
-                                    .expect(&format!("Failed to get file {}",filename))
+                                    .expect(&format!("Failed to get file {}", filename))
                                     .contents(),
                             )
                         }


### PR DESCRIPTION
I noticed there was a lot of panics in my console when accessing the swagger-ui page and I tracked it down to the contents_utf8() call in the actix-web plugin.

I replaced it with a single contents() so it should work for any file type and not just text.
I also added an expect call with a message instead of just using unwrap()