### PR TITLE
fix(clippy): disable must_use on the actix_web plugin

### DIFF
--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg(any(feature = "actix2", feature = "actix3"))]
+#![allow(clippy::return_self_not_must_use)]
 
 #[cfg(feature = "actix2")]
 extern crate actix_web2 as actix_web;


### PR DESCRIPTION
Adding must_use could be a breaking change - in these cases it probably wouldn't be
since these are functions that return a Self, but let's avoid that for now.