### PR TITLE
fix: add extensions to root level of spec

### DIFF
--- a/core/src/v2/mod.rs
+++ b/core/src/v2/mod.rs
@@ -60,6 +60,7 @@ impl<S: Schema + Default> ResolvableApi<S> {
             security: self.security,
             security_definitions: self.security_definitions,
             tags: self.tags,
+            extensions: self.extensions,
         })
     }
 }

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -189,6 +189,13 @@ pub struct Api<P, R, S> {
     #[serde(skip)]
     pub spec_format: SpecFormat,
     pub info: Info,
+
+    #[serde(
+        flatten,
+        skip_serializing_if = "BTreeMap::is_empty",
+        deserialize_with = "crate::v2::extensions::deserialize_extensions"
+    )]
+    pub extensions: BTreeMap<String, serde_json::Value>,
 }
 
 /// The format used by spec (JSON/YAML).

--- a/core/src/v3/openapi.rs
+++ b/core/src/v3/openapi.rs
@@ -24,6 +24,13 @@ impl From<v2::DefaultApiRaw> for openapiv3::OpenAPI {
                 i.insert(b.0.to_string(), b.1.clone().into());
                 i
             });
+        components.extensions =
+            v2.extensions
+                .into_iter()
+                .fold(indexmap::IndexMap::new(), |mut i, (k, v)| {
+                    i.insert(k, v);
+                    i
+                });
         spec.paths = openapiv3::Paths {
             paths: v2.paths.iter().fold(indexmap::IndexMap::new(), |mut i, b| {
                 i.insert(

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -1608,6 +1608,13 @@ fn test_tags() {
                 ..Default::default()
             };
 
+            let mut root_extensions = BTreeMap::new();
+            root_extensions.insert(
+                "x-root-level-extension".to_string(),
+                serde_json::Value::Bool(false),
+            );
+            spec.extensions = root_extensions;
+
             App::new()
                 .wrap_api_with_spec(spec)
                 .with_json_spec_at("/api/spec")
@@ -1649,6 +1656,7 @@ fn test_tags() {
                         "version":"0.1",
                         "x-my-attr":true
                     },
+                    "x-root-level-extension": false,
                     "paths":{
                         "/images/pets":{
                             "get":{


### PR DESCRIPTION
as a follow up to #387 which added extensions to the Info object, this PR adds extensions to the root of the OpenAPI document.