### PR TITLE
Implement actix schema generator for tagged enums

### DIFF
--- a/book/actix-plugin.md
+++ b/book/actix-plugin.md
@@ -185,7 +185,8 @@ Similarly, if we were to use other extractors like `web::Query<T>`, `web::Form<T
 
 #### Known limitations
 
-- **Enums:** OpenAPI (v2) itself supports using simple enums (i.e., with unit variants), but Rust and serde has support for variants with fields and tuples. I still haven't looked deep enough either to say whether this can/cannot be done in OpenAPI or find an elegant way to represent this in OpenAPI.
+- **Tuples:** Tuples with more than one field are currently not supported.
+- **Enums:** Enums with fields will be serialized [according to serde](https://serde.rs/enum-representations.html). Enum variants with unnamed (tuple) fields are currently not supported though.
 - **Functions returning abstractions:** The plugin has no way to obtain any useful information from functions returning abstractions such as `HttpResponse`, `impl Responder` or containers such as `Result<T, E>` containing those abstractions. So currently, the plugin silently ignores these types, which results in an empty value in your hosted specification.
 
 #### Missing features

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -54,6 +54,16 @@ pub trait Schema: Sized {
     /// - `serde_json::Value` works for both JSON and YAML.
     fn enum_variants(&self) -> Option<&[serde_json::Value]>;
 
+    /// More complex enum variants, where each has it's own schema.
+    fn any_of(&self) -> Option<&Vec<Resolvable<Self>>>;
+
+    /// A constant value for this schema. It's `serde_json::Value`
+    /// because:
+    ///
+    /// - Constants are allowed to have any value.
+    /// - `serde_json::Value` works for both JSON and YAML.
+    fn const_value(&self) -> Option<&serde_json::Value>;
+
     /// Returns whether this definition "is" or "has" `Any` type.
     fn contains_any(&self) -> bool {
         _schema_contains_any(self, vec![])

--- a/macros/src/core.rs
+++ b/macros/src/core.rs
@@ -182,6 +182,20 @@ pub fn emit_v2_schema_struct(input: TokenStream) -> TokenStream {
                     Some(&self.enum_)
                 }
             }
+
+            #[inline]
+            fn any_of(&self) -> Option<&Vec<paperclip::v2::models::Resolvable<Self>>> {
+                if self.any_of.is_empty() {
+                    None
+                } else {
+                    Some(&self.any_of)
+                }
+            }
+
+            #[inline]
+            fn const_value(&self) -> Option<&serde_json::Value> {
+                self.const_.as_ref()
+            }
         }
     });
 
@@ -306,6 +320,18 @@ fn schema_fields(name: &Ident, is_ref: bool) -> proc_macro2::TokenStream {
     gen.extend(quote!(
         #[serde(default, rename = "enum", skip_serializing_if = "Vec::is_empty")]
         pub enum_: Vec<serde_json::Value>,
+    ));
+
+    gen.extend(quote!(
+        #[serde(default, rename = "anyOf", skip_serializing_if = "Vec::is_empty")]
+        pub any_of: Vec<
+    ));
+    add_self(&mut gen);
+    gen.extend(quote!(>,));
+
+    gen.extend(quote!(
+        #[serde(default, rename="const", skip_serializing_if = "Option::is_none")]
+        pub const_: Option<serde_json::Value>,
     ));
 
     gen.extend(quote!(

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -3247,7 +3247,7 @@ fn test_enum_variants() {
         /// It's a dog
         Dog,
         /// It's a cat
-        Cat{ meow: bool },
+        Cat { meow: bool },
         #[allow(dead_code)]
         #[serde(skip)]
         Tree,
@@ -3257,12 +3257,12 @@ fn test_enum_variants() {
 
     /// Pets are awesome!
     #[derive(Deserialize, Serialize, Apiv2Schema)]
-    #[serde(rename_all = "lowercase", tag="type")]
+    #[serde(rename_all = "lowercase", tag = "type")]
     enum PetClassInternal {
         /// It's a dog
         Dog,
         /// It's a cat
-        Cat{ meow: bool },
+        Cat { meow: bool },
         #[allow(dead_code)]
         #[serde(skip)]
         Tree,
@@ -3272,12 +3272,12 @@ fn test_enum_variants() {
 
     /// Pets are awesome!
     #[derive(Deserialize, Serialize, Apiv2Schema)]
-    #[serde(rename_all = "lowercase", tag="type", content="c")]
+    #[serde(rename_all = "lowercase", tag = "type", content = "c")]
     enum PetClassAdjacent {
         /// It's a dog
         Dog,
         /// It's a cat
-        Cat{ meow: bool },
+        Cat { meow: bool },
         #[allow(dead_code)]
         #[serde(skip)]
         Tree,
@@ -3290,9 +3290,9 @@ fn test_enum_variants() {
     #[serde(rename_all = "lowercase", untagged)]
     enum PetClassUntagged {
         /// It's a dog
-        Dog{ woof: bool },
+        Dog { woof: bool },
         /// It's a cat
-        Cat{ meow: bool },
+        Cat { meow: bool },
         #[allow(dead_code)]
         #[serde(skip)]
         Tree,
@@ -3319,7 +3319,7 @@ fn test_enum_variants() {
     #[get("/untagged")]
     #[api_v2_operation]
     fn untagged() -> impl Future<Output = Result<web::Json<PetClassUntagged>, Error>> {
-        fut_ok(web::Json(PetClassUntagged::Dog{woof: true}))
+        fut_ok(web::Json(PetClassUntagged::Dog { woof: true }))
     }
 
     run_and_check_app(


### PR DESCRIPTION
Resolves #97.

## About 
This pr implements schema generation for complex enums with serde's tag system.

Supported are all types of tagging ([see here](https://serde.rs/enum-representations.html)), except for the enum tuples.
Tuple schema generation is currently not implemented correctly anyway, so that should go into another pr.

This pr currently uses `anyOf` instead of `oneOf` to cover some possible edge cases, where serde would just use the first variant that matches (especially visible in `untagged` enums).

To be able to implement this, this pr adds `any_of` and `const` to the internal schema representation.

## Up for discussion
- Usage of `anyOf` vs. `oneOf` as described above.
- Currently the old enum system is kept for enums that use the default tagging (`external`) and that only have unit variants.
  This makes it effectively impossible to add descriptions for the enum variants.
  Possible workarounds:
  - Check for documentation on each variant and if present, go for the new `any_of` system.
  - Get rid of the old `enum` system and just use `any_of` for everything.

## Other notes
- The files that I worked on in this pr were incredibly huge, making editing more painful than it needs to be.
- Let me know if there's any more documentation needed :)