### PR TITLE
chore(nix): update rust toolchain date

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ profile ? "nightly", date ? "2021-11-22", oxalica ? "194016e6b086bfa5965aeb8979c58b93e03e2485" }:
+{ profile ? "nightly", date ? "2022-02-22", oxalica ? "194016e6b086bfa5965aeb8979c58b93e03e2485" }:
 let
   oxalica_overlay = builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/${oxalica}.tar.gz";
   pkgs = import <nixpkgs> {

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,8 @@
-{ profile ? "nightly", date ? "2021-11-22" }:
+{ profile ? "nightly", date ? "2021-11-22", oxalica ? "194016e6b086bfa5965aeb8979c58b93e03e2485" }:
 let
-  oxalica = builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/a1b1977429de5d69a332dd87700ffb00525335f9.tar.gz";
+  oxalica_overlay = builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/${oxalica}.tar.gz";
   pkgs = import <nixpkgs> {
-    overlays = [ (import oxalica) ];
+    overlays = [ (import oxalica_overlay) ];
   };
 in
 pkgs.mkShell {


### PR DESCRIPTION
Update to "2022-02-22" by default.
Oxalica version is now also configurable.

Example if you want to go latest on all:
`nix-shell --run zsh --argstr date latest --argstr oxalica master`