### PR TITLE
Re-expose app_data on ServiceConfig

### DIFF
--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -753,7 +753,7 @@ impl<'a> ServiceConfig<'a> {
     /// Proxy for [`actix_web::web::ServiceConfig::app_data`](https://docs.rs/actix-web/3.3.2/actix_web/web/struct.ServiceConfig.html#method.app_data).
     ///
     /// **NOTE:** This doesn't affect spec generation.
-    #[cfg(feature = "actix3")]
+    #[cfg(any(feature = "actix3", feature = "actix4"))]
     pub fn app_data<U: 'static>(&mut self, data: U) -> &mut Self {
         self.inner.app_data(data);
         self

--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -750,10 +750,9 @@ impl<'a> ServiceConfig<'a> {
         self
     }
 
-    /// Proxy for [`actix_web::web::ServiceConfig::app_data`](https://docs.rs/actix-web/3.3.2/actix_web/web/struct.ServiceConfig.html#method.app_data).
+    /// Proxy for [`actix_web::web::ServiceConfig::app_data`](https://docs.rs/actix-web/4.0.1/actix_web/web/struct.ServiceConfig.html#method.app_data).
     ///
     /// **NOTE:** This doesn't affect spec generation.
-    #[cfg(any(feature = "actix3", feature = "actix4"))]
     pub fn app_data<U: 'static>(&mut self, data: U) -> &mut Self {
         self.inner.app_data(data);
         self


### PR DESCRIPTION
Hi,

I don't know if it's something you want to do but it appears that `app_data` is not exposed anymore on `paperclip_actix::web::ServiceConfig` when using actix4.