### PR TITLE
Feat - actix web validator support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -62,14 +62,14 @@ jobs:
         timeout-minutes: 10
         with:
           command: build
-          args: --all --features "actix4 cli chrono url uuid swagger-ui v3"
+          args: --all --features "actix4 cli chrono url uuid swagger-ui v3 actix4-validator"
 
       - name: Build actix3 features
         uses: actions-rs/cargo@v1
         timeout-minutes: 10
         with:
           command: build
-          args: --all --features "actix3 cli chrono url uuid swagger-ui v3"
+          args: --all --features "actix3 cli chrono url uuid swagger-ui v3 actix3-validator"
 
       - name: Build actix2 features
         uses: actions-rs/cargo@v1
@@ -83,14 +83,14 @@ jobs:
         timeout-minutes: 20
         with:
           command: test
-          args: --all --features "actix4 cli chrono url uuid swagger-ui v3"
+          args: --all --features "actix4 cli chrono url uuid swagger-ui v3 actix4-validator"
 
       - name: Run actix3 tests
         uses: actions-rs/cargo@v1
         timeout-minutes: 20
         with:
           command: test
-          args: --all --features "actix3 cli chrono url uuid swagger-ui v3"
+          args: --all --features "actix3 cli chrono url uuid swagger-ui v3 actix3-validator"
 
       - name: Run actix2 tests
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,4 @@ required-features = ["v2", "codegen"]
 
 [[test]]
 name = "test_app"
-required-features = ["cli", "actix-base", "uuid", "chrono", "swagger-ui", "actix3-validator"]
+required-features = ["cli", "actix-base", "uuid", "chrono", "swagger-ui", "actix4-validator"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ indexmap = { version = "1.0", features = ["serde-1", "std"], optional = true }
 actix-rt1 = { version = "1.0", package = "actix-rt" }
 actix-service1 = { version = "1", package = "actix-service" }
 actix-service2 = { version = "2", package = "actix-service" }
+actix-web-validator2 = { version = "2.2", package = "actix-web-validator" }
+actix-web-validator3 = { version = "3.0", package = "actix-web-validator" }
 actix-web2 = { version = "2", default-features = false, package = "actix-web" }
 actix-web3 = { version = "3", default-features = false, package = "actix-web" }
 actix-web4 = { version = "4", default-features = false, package = "actix-web" }
@@ -59,6 +61,8 @@ reqwest = { version = "0.10", features = ["blocking", "json"] }
 log = { version = "0.4", features = ["kv_unstable"] }
 insta = "1.0"
 env_logger = "0.8"
+validator12 = { version = "0.12", features = ["derive"], package = "validator" }
+validator14 = { version = "0.14", features = ["derive"], package = "validator" }
 
 [features]
 # actix-web support
@@ -85,6 +89,8 @@ v3 = ["openapiv3", "indexmap", "v2", "paperclip-core/v3", "paperclip-actix/v3"]
 actix-multipart = ["paperclip-core/actix-multipart"]
 actix-session = ["paperclip-core/actix-session"]
 actix-files = ["paperclip-core/actix-files"]
+actix3-validator = ["paperclip-core/actix3-validator"]
+actix4-validator = ["paperclip-core/actix4-validator"]
 chrono = ["paperclip-core/chrono"]
 rust_decimal = ["paperclip-core/rust_decimal"]
 url = ["paperclip-core/url"]
@@ -109,4 +115,4 @@ required-features = ["v2", "codegen"]
 
 [[test]]
 name = "test_app"
-required-features = ["cli", "actix-base", "uuid", "chrono", "swagger-ui"]
+required-features = ["cli", "actix-base", "uuid", "chrono", "swagger-ui", "actix3-validator"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,4 @@ required-features = ["v2", "codegen"]
 
 [[test]]
 name = "test_app"
-required-features = ["cli", "actix-base", "uuid", "chrono", "swagger-ui", "actix4-validator"]
+required-features = ["cli", "actix-base", "uuid", "chrono", "swagger-ui"]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build:
 	cargo build --features cli
 
 test:
-	cargo test --all --features "actix4 cli chrono uuid swagger-ui"
+	cargo test --all --features "actix4 cli chrono uuid swagger-ui actix4-validator"
 
 	# We test this one seperately as it affects the generated spec, which'd fail the other tests
 	cargo test test_module_path_in_definition_name --features "actix4 cli chrono uuid swagger-ui path-in-definition"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build:
 test:
 	cargo test --all --features "actix4 cli chrono uuid swagger-ui actix4-validator"
 
-	# We test this one seperately as it affects the generated spec, which'd fail the other tests
+	# We test this one separately as it affects the generated spec, which'd fail the other tests
 	cargo test test_module_path_in_definition_name --features "actix4 cli chrono uuid swagger-ui path-in-definition"
 
 	# Compile the code generated through tests.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test:
 	cargo test --all --features "actix4 cli chrono uuid swagger-ui actix4-validator"
 
 	# We test this one separately as it affects the generated spec, which'd fail the other tests
-	cargo test test_module_path_in_definition_name --features "actix4 cli chrono uuid swagger-ui path-in-definition"
+	cargo test test_module_path_in_definition_name --features "actix4 cli chrono uuid swagger-ui path-in-definition actix4-validator"
 
 	# Compile the code generated through tests.
 	cd tests/test_pet && cargo check

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,10 @@ url = { version = "2", optional = true }
 uuid = { version = "0", optional = true }
 thiserror = "1.0"
 serde_qs = { version = "0", optional = true }
+actix-web-validator2 = { version = "2.2", optional = true, package = "actix-web-validator" }
+actix-web-validator3 = { version = "3.0", optional = true, package = "actix-web-validator" }
+validator12 = { version = "0.12", features = ["derive"], optional = true, package = "validator" }
+validator14 = { version = "0.14", features = ["derive"], optional = true, package = "validator" }
 openapiv3 = { version = "1.0.0-beta.5", optional = true }
 indexmap = { version = "1.0", features = ["serde-1", "std"], optional = true }
 
@@ -42,6 +46,8 @@ actix4 = ["actix-base", "actix-web4"]
 actix3 = ["actix-base", "actix-web3"]
 actix2 = ["actix-base", "actix-web2"]
 actix-base = ["v2", "pin-project"]
+actix3-validator = ["actix-web-validator2", "validator12"]
+actix4-validator = ["actix-web-validator3", "validator14"]
 
 # Enable nightly if nightly compiler can be allowed
 nightly = ["paperclip-macros/nightly"]

--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -348,8 +348,8 @@ where
 }
 
 #[cfg(all(
-any(feature = "actix4-validator", feature = "actix3-validator"),
-feature = "nightly"
+    any(feature = "actix4-validator", feature = "actix3-validator"),
+    feature = "nightly"
 ))]
 impl<T> Apiv2Schema for ValidatedJson<T> {
     fn name() -> Option<String> {
@@ -374,8 +374,8 @@ impl<T: Apiv2Schema> Apiv2Schema for ValidatedJson<T> {
 
 #[cfg(any(feature = "actix4-validator", feature = "actix3-validator"))]
 impl<T> OperationModifier for ValidatedJson<T>
-    where
-        T: Apiv2Schema,
+where
+    T: Apiv2Schema,
 {
     fn update_parameter(op: &mut DefaultOperationRaw) {
         op.parameters.push(Either::Right(Parameter {

--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "actix3-validator")]
+extern crate actix_web_validator2 as actix_web_validator;
+#[cfg(feature = "actix4-validator")]
+extern crate actix_web_validator3 as actix_web_validator;
+
 #[cfg(feature = "actix-multipart")]
 use super::schema::TypedData;
 use super::{
@@ -23,6 +28,11 @@ use actix_web::{
 
 use pin_project::pin_project;
 
+#[cfg(any(feature = "actix4-validator", feature = "actix3-validator"))]
+use actix_web_validator::{
+    Json as ValidatedJson, Path as ValidatedPath, QsQuery as ValidatedQsQuery,
+    Query as ValidatedQuery,
+};
 use serde::Serialize;
 #[cfg(feature = "serde_qs")]
 use serde_qs::actix::QsQuery;
@@ -333,6 +343,64 @@ where
     }
 }
 
+#[cfg(all(
+any(feature = "actix4-validator", feature = "actix3-validator"),
+feature = "nightly"
+))]
+impl<T> Apiv2Schema for ValidatedJson<T> {
+    default const NAME: Option<&'static str> = None;
+
+    default fn raw_schema() -> DefaultSchemaRaw {
+        Default::default()
+    }
+}
+
+#[cfg(any(feature = "actix4-validator", feature = "actix3-validator"))]
+impl<T: Apiv2Schema> Apiv2Schema for ValidatedJson<T> {
+    const NAME: Option<&'static str> = T::NAME;
+
+    fn raw_schema() -> DefaultSchemaRaw {
+        T::raw_schema()
+    }
+}
+
+#[cfg(any(feature = "actix4-validator", feature = "actix3-validator"))]
+impl<T> OperationModifier for ValidatedJson<T>
+    where
+        T: Apiv2Schema,
+{
+    fn update_parameter(op: &mut DefaultOperationRaw) {
+        op.parameters.push(Either::Right(Parameter {
+            description: None,
+            in_: ParameterIn::Body,
+            name: "body".into(),
+            required: true,
+            schema: Some({
+                let mut def = T::schema_with_ref();
+                def.retain_ref();
+                def
+            }),
+            ..Default::default()
+        }));
+    }
+
+    fn update_response(op: &mut DefaultOperationRaw) {
+        op.responses.insert(
+            "200".into(),
+            Either::Right(Response {
+                // TODO: Support configuring other 2xx codes using macro attribute.
+                description: Some("OK".into()),
+                schema: Some({
+                    let mut def = T::schema_with_ref();
+                    def.retain_ref();
+                    def
+                }),
+                ..Default::default()
+            }),
+        );
+    }
+}
+
 #[cfg(feature = "actix-multipart")]
 impl OperationModifier for actix_multipart::Multipart {
     fn update_parameter(op: &mut DefaultOperationRaw) {
@@ -439,8 +507,59 @@ impl_param_extractor!(Query<T> => Query);
 impl_param_extractor!(Form<T> => FormData);
 #[cfg(feature = "serde_qs")]
 impl_param_extractor!(QsQuery<T> => Query);
+#[cfg(any(feature = "actix4-validator", feature = "actix3-validator"))]
+impl_param_extractor!(ValidatedPath<T> => Path);
+#[cfg(any(feature = "actix4-validator", feature = "actix3-validator"))]
+impl_param_extractor!(ValidatedQuery<T> => Query);
+#[cfg(any(feature = "actix4-validator", feature = "actix3-validator"))]
+impl_param_extractor!(ValidatedQsQuery<T> => Query);
 
 macro_rules! impl_path_tuple ({ $($ty:ident),+ } => {
+    #[cfg(all(any(feature = "actix4-validator", feature = "actix3-validator"), feature = "nightly"))]
+    impl<$($ty,)+> Apiv2Schema for ValidatedPath<($($ty,)+)> {}
+
+    #[cfg(all(not(feature = "nightly"), any(feature = "actix4-validator", feature = "actix3-validator")))]
+    impl<$($ty: Apiv2Schema,)+> Apiv2Schema for ValidatedPath<($($ty,)+)> {}
+
+    #[cfg(any(feature = "actix4-validator", feature = "actix3-validator"))]
+    impl<$($ty,)+> OperationModifier for ValidatedPath<($($ty,)+)>
+        where $($ty: Apiv2Schema,)+
+    {
+        fn update_parameter(op: &mut DefaultOperationRaw) {
+            $(
+                let def = $ty::raw_schema();
+                if def.properties.is_empty() {
+                    op.parameters.push(Either::Right(Parameter {
+                        // NOTE: We're setting empty name, because we don't know
+                        // the name in this context. We'll get it when we add services.
+                        name: String::new(),
+                        in_: ParameterIn::Path,
+                        required: true,
+                        data_type: def.data_type,
+                        format: def.format,
+                        enum_: def.enum_,
+                        description: def.description,
+                        ..Default::default()
+                    }));
+                }
+                for (k, v) in def.properties {
+                    op.parameters.push(Either::Right(Parameter {
+                        in_: ParameterIn::Path,
+                        required: def.required.contains(&k),
+                        data_type: v.data_type,
+                        format: v.format,
+                        enum_: v.enum_,
+                        description: v.description,
+                        collection_format: None, // this defaults to csv
+                        items: v.items.as_deref().map(map_schema_to_items),
+                        name: k,
+                        ..Default::default()
+                    }));
+                }
+            )+
+        }
+    }
+
     #[cfg(feature = "nightly")]
     impl<$($ty,)+> Apiv2Schema for Path<($($ty,)+)> {}
 

--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -352,7 +352,9 @@ any(feature = "actix4-validator", feature = "actix3-validator"),
 feature = "nightly"
 ))]
 impl<T> Apiv2Schema for ValidatedJson<T> {
-    default const NAME: Option<&'static str> = None;
+    fn name() -> Option<String> {
+        None
+    }
 
     default fn raw_schema() -> DefaultSchemaRaw {
         Default::default()
@@ -361,7 +363,9 @@ impl<T> Apiv2Schema for ValidatedJson<T> {
 
 #[cfg(any(feature = "actix4-validator", feature = "actix3-validator"))]
 impl<T: Apiv2Schema> Apiv2Schema for ValidatedJson<T> {
-    const NAME: Option<&'static str> = T::NAME;
+    fn name() -> Option<String> {
+        T::name()
+    }
 
     fn raw_schema() -> DefaultSchemaRaw {
         T::raw_schema()

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -396,7 +396,10 @@ fn test_simple_app() {
 #[allow(dead_code)]
 fn test_params() {
     #[derive(Deserialize, Apiv2Schema)]
-    #[cfg_attr(any(feature = "actix3-validator", feature = "actix4-validator"), derive(Validate))]
+    #[cfg_attr(
+        any(feature = "actix3-validator", feature = "actix4-validator"),
+        derive(Validate)
+    )]
     struct KnownResourceBadge {
         resource: String,
         name: String,
@@ -421,20 +424,29 @@ fn test_params() {
 
     /// KnownBadge Id4 Doc
     #[derive(Serialize, Deserialize, Apiv2Schema)]
-    #[cfg_attr(any(feature = "actix3-validator", feature = "actix4-validator"), derive(Validate))]
+    #[cfg_attr(
+        any(feature = "actix3-validator", feature = "actix4-validator"),
+        derive(Validate)
+    )]
     struct KnownBadgeId4 {
         id: String,
     }
 
     #[derive(Deserialize, Apiv2Schema)]
-    #[cfg_attr(any(feature = "actix3-validator", feature = "actix4-validator"), derive(Validate))]
+    #[cfg_attr(
+        any(feature = "actix3-validator", feature = "actix4-validator"),
+        derive(Validate)
+    )]
     struct BadgeParams {
         res: Option<u16>,
         colors: Vec<String>,
     }
 
     #[derive(Deserialize, Apiv2Schema)]
-    #[cfg_attr(any(feature = "actix3-validator", feature = "actix4-validator"), derive(Validate))]
+    #[cfg_attr(
+        any(feature = "actix3-validator", feature = "actix4-validator"),
+        derive(Validate)
+    )]
     struct BadgeBody {
         /// JSON value
         json: Option<serde_json::Value>,

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -39,6 +39,7 @@ use actix_web::{
     dev::{Payload, ServiceRequest, ServiceResponse},
     App, Error, FromRequest, HttpRequest, HttpServer, Responder,
 };
+#[cfg(any(feature = "actix3-validator", feature = "actix4-validator"))]
 use actix_web_validator::{Json as ValidatedJson, Path as ValidatedPath, Query as ValidatedQuery};
 use futures::future::{ok as fut_ok, ready, Future, Ready};
 use once_cell::sync::Lazy;
@@ -50,6 +51,7 @@ use paperclip::{
     v2::models::{DefaultApiRaw, Info, Tag},
 };
 use parking_lot::Mutex;
+#[cfg(any(feature = "actix3-validator", feature = "actix4-validator"))]
 use validator::Validate;
 
 use std::{
@@ -393,7 +395,8 @@ fn test_simple_app() {
 #[test]
 #[allow(dead_code)]
 fn test_params() {
-    #[derive(Deserialize, Apiv2Schema, Validate)]
+    #[derive(Deserialize, Apiv2Schema)]
+    #[cfg_attr(any(feature = "actix3-validator", feature = "actix4-validator"), derive(Validate))]
     struct KnownResourceBadge {
         resource: String,
         name: String,
@@ -417,18 +420,21 @@ fn test_params() {
     );
 
     /// KnownBadge Id4 Doc
-    #[derive(Serialize, Deserialize, Apiv2Schema, Validate)]
+    #[derive(Serialize, Deserialize, Apiv2Schema)]
+    #[cfg_attr(any(feature = "actix3-validator", feature = "actix4-validator"), derive(Validate))]
     struct KnownBadgeId4 {
         id: String,
     }
 
-    #[derive(Deserialize, Apiv2Schema, Validate)]
+    #[derive(Deserialize, Apiv2Schema)]
+    #[cfg_attr(any(feature = "actix3-validator", feature = "actix4-validator"), derive(Validate))]
     struct BadgeParams {
         res: Option<u16>,
         colors: Vec<String>,
     }
 
-    #[derive(Deserialize, Apiv2Schema, Validate)]
+    #[derive(Deserialize, Apiv2Schema)]
+    #[cfg_attr(any(feature = "actix3-validator", feature = "actix4-validator"), derive(Validate))]
     struct BadgeBody {
         /// JSON value
         json: Option<serde_json::Value>,
@@ -515,8 +521,15 @@ fn test_params() {
         ready("")
     }
 
+    #[cfg(any(feature = "actix3-validator", feature = "actix4-validator"))]
     #[api_v2_operation]
     fn get_known_badge_5(_p1: ValidatedPath<KnownBadgeId4>) -> impl Future<Output = &'static str> {
+        ready("")
+    }
+
+    #[cfg(not(any(feature = "actix3-validator", feature = "actix4-validator")))]
+    #[api_v2_operation]
+    fn get_known_badge_5(_p1: web::Path<KnownBadgeId4>) -> impl Future<Output = &'static str> {
         ready("")
     }
 
@@ -553,6 +566,7 @@ fn test_params() {
         ready("")
     }
 
+    #[cfg(any(feature = "actix3-validator", feature = "actix4-validator"))]
     #[api_v2_operation]
     fn post_badge_4(
         _p: web::Path<u32>,
@@ -561,10 +575,29 @@ fn test_params() {
         ready("")
     }
 
+    #[cfg(not(any(feature = "actix3-validator", feature = "actix4-validator")))]
+    #[api_v2_operation]
+    fn post_badge_4(
+        _p: web::Path<u32>,
+        _b: web::Json<BadgeBody>,
+    ) -> impl Future<Output = &'static str> {
+        ready("")
+    }
+
+    #[cfg(any(feature = "actix3-validator", feature = "actix4-validator"))]
     #[api_v2_operation]
     fn patch_badge_4(
         _p: ValidatedPath<KnownResourceBadge>,
         _q: ValidatedQuery<BadgeParams>,
+    ) -> impl Future<Output = &'static str> {
+        ready("")
+    }
+
+    #[cfg(not(any(feature = "actix3-validator", feature = "actix4-validator")))]
+    #[api_v2_operation]
+    fn patch_badge_4(
+        _p: web::Path<KnownResourceBadge>,
+        _q: web::Query<BadgeParams>,
     ) -> impl Future<Output = &'static str> {
         ready("")
     }

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -490,13 +490,6 @@ fn test_params() {
         web::Json(is_data_empty(app.get_ref()).await)
     }
 
-    // Use dumb check_data_ref_async function for actix2 instead of real one
-    #[cfg(feature = "actix2")]
-    #[api_v2_operation]
-    async fn check_data_ref_async(app: web::Data<AppState>) -> web::Json<bool> {
-        web::Json(is_data_empty(app.get_ref()).await)
-    }
-
     #[api_v2_operation]
     fn get_resource_2(_p: web::Path<u32>) -> impl Future<Output = &'static str> {
         ready("")


### PR DESCRIPTION
Hi,

I would like to bring [validator](https://docs.rs/validator/latest/validator/) support to paperclip.
To do so I use [actix-web-validator](https://github.com/rambler-digital-solutions/actix-web-validator) as a dependency.

I did add this feature for both actix3 and actix4. I personally use it for month now in the company I'm working for.