### PR TITLE
Fixed #407

### DIFF
--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -1569,12 +1569,13 @@ impl super::Method {
         let variant: proc_macro2::TokenStream = self.variant().parse()?;
         let handler_name_str = handler_name.to_string();
 
-        let uri = uri.to_string()
-            .replace("\"", ""); // The uri is a string lit, which contains quotes, remove them
+        let uri = uri.to_string().replace('\"', ""); // The uri is a string lit, which contains quotes, remove them
 
-        let uri_fmt = if !uri.starts_with("/") {
+        let uri_fmt = if !uri.starts_with('/') {
             format!("/{}", uri)
-        } else { uri };
+        } else {
+            uri
+        };
 
         Ok(quote! {
             #[allow(non_camel_case_types, missing_docs)]

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -1569,6 +1569,13 @@ impl super::Method {
         let variant: proc_macro2::TokenStream = self.variant().parse()?;
         let handler_name_str = handler_name.to_string();
 
+        let uri = uri.to_string()
+            .replace("\"", ""); // The uri is a string lit, which contains quotes, remove them
+
+        let uri_fmt = if !uri.starts_with("/") {
+            format!("/{}", uri)
+        } else { uri };
+
         Ok(quote! {
             #[allow(non_camel_case_types, missing_docs)]
             pub struct #handler_name;
@@ -1576,7 +1583,7 @@ impl super::Method {
             impl #handler_name {
                 fn resource() -> paperclip::actix::web::Resource {
                     #handler_fn
-                    paperclip::actix::web::Resource::new(#uri)
+                    paperclip::actix::web::Resource::new(#uri_fmt)
                         .name(#handler_name_str)
                         .guard(actix_web::guard::#variant())
                         .route(paperclip::actix::web::#method().to(#handler_name))
@@ -1591,7 +1598,7 @@ impl super::Method {
 
             impl paperclip::actix::Mountable for #handler_name {
                 fn path(&self) -> &str {
-                    #uri
+                    #uri_fmt
                 }
 
                 fn operations(

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -119,6 +119,7 @@ impl Responder for Pet {
 
 #[test]
 fn test_simple_app() {
+
     #[api_v2_operation]
     fn echo_pet(body: web::Json<Pet>) -> impl Future<Output = Result<web::Json<Pet>, Error>> {
         fut_ok(body)
@@ -156,13 +157,20 @@ fn test_simple_app() {
         NoContent
     }
 
+    #[api_v2_operation]
+    #[paperclip::actix::post("no-slash")]
+    async fn path_without_slash() -> NoContent {
+        NoContent
+    }
+
     fn config(cfg: &mut web::ServiceConfig) {
         cfg.service(web::resource("/echo").route(web::post().to(echo_pet)))
             .service(web::resource("/async_echo").route(web::post().to(echo_pet_async)))
             .service(web::resource("/async_echo_2").route(web::post().to(echo_pet_async_2)))
             .service(web::resource("/adopt").route(web::post().to(adopt_pet)))
             .service(web::resource("/nothing").route(web::get().to(nothing)))
-            .service(web::resource("/random").to(some_pet));
+            .service(web::resource("/random").to(some_pet))
+            .service(path_without_slash);
     }
 
     run_and_check_app(
@@ -370,6 +378,15 @@ fn test_simple_app() {
                         }
                       }
                     },
+                    "/api/no-slash": {
+                      "post": {
+                        "responses": {
+                          "204": {
+                            "description": "No Content"
+                          }
+                        }
+                      }
+                    }
                   },
                   "swagger": "2.0"
                 }),

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -119,7 +119,6 @@ impl Responder for Pet {
 
 #[test]
 fn test_simple_app() {
-
     #[api_v2_operation]
     fn echo_pet(body: web::Json<Pet>) -> impl Future<Output = Result<web::Json<Pet>, Error>> {
         fut_ok(body)


### PR DESCRIPTION
## Summary
Solves #407 

When using proc macros to declare the path to a route, e.g:
```rs
#[post("foo")]
async fn foo() {}
```
No `/` is prefixed to the path `foo`. It is recommended by the Actix documentation to include the `/` in the path (i.e. `/foo`), but it is not a requirment and things will work just fine without it. However, to my knowledge it does need to be present in the OpenAPI documentation. This PR addresses this issue.

## The way it works
I've altered the proc macro which is invoked here. It now checks if the provided path starts with a `/`, if not it will add it.

## Backwards compatibility
Backwards compatibility will not be broken. Specs might change, if users were using 'unprefixed' paths, those paths will now be prefixed

## Tests
I've added a test in `tests/test_app.rs`: `test_simple_app`, this passes.

Thanks!