### PR TITLE
Fix $ref URIs to be RFC3986-compliant

### DIFF
--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -293,9 +293,9 @@ pub trait Apiv2Schema {
     fn schema_with_ref() -> DefaultSchemaRaw {
         let mut def = Self::raw_schema();
         if let Some(n) = Self::name() {
-            def.reference = Some(String::from("#/definitions/") + &n);
+            def.reference = Some(String::from("#/definitions/") + &n.replace('<', "%3C").replace('>', "%3E"));
         } else if let Some(n) = def.name.as_ref() {
-            def.reference = Some(String::from("#/definitions/") + n);
+            def.reference = Some(String::from("#/definitions/") + &n.replace('<', "%3C").replace('>', "%3E"));
         }
         if !Self::description().is_empty() {
             def.description = Some(Self::description().to_owned());

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -293,9 +293,11 @@ pub trait Apiv2Schema {
     fn schema_with_ref() -> DefaultSchemaRaw {
         let mut def = Self::raw_schema();
         if let Some(n) = Self::name() {
-            def.reference = Some(String::from("#/definitions/") + &n.replace('<', "%3C").replace('>', "%3E"));
+            def.reference =
+                Some(String::from("#/definitions/") + &n.replace('<', "%3C").replace('>', "%3E"));
         } else if let Some(n) = def.name.as_ref() {
-            def.reference = Some(String::from("#/definitions/") + &n.replace('<', "%3C").replace('>', "%3E"));
+            def.reference =
+                Some(String::from("#/definitions/") + &n.replace('<', "%3C").replace('>', "%3E"));
         }
         if !Self::description().is_empty() {
             def.description = Some(Self::description().to_owned());

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -3716,7 +3716,7 @@ fn test_schema_with_generics() {
                                         "name": "body",
                                         "required": true,
                                         "schema": {
-                                            "$ref": "#/definitions/Pet<Cat>",
+                                            "$ref": "#/definitions/Pet%3CCat%3E",
                                         },
                                     },
                                 ],
@@ -3724,7 +3724,7 @@ fn test_schema_with_generics() {
                                     "200": {
                                         "description": "OK",
                                         "schema": {
-                                            "$ref": "#/definitions/Pet<Cat>",
+                                            "$ref": "#/definitions/Pet%3CCat%3E",
                                         },
                                     },
                                 },
@@ -3738,7 +3738,7 @@ fn test_schema_with_generics() {
                                         "name": "body",
                                         "required": true,
                                         "schema": {
-                                            "$ref": "#/definitions/Pet<Dog>",
+                                            "$ref": "#/definitions/Pet%3CDog%3E",
                                         },
                                     },
                                 ],
@@ -3746,7 +3746,7 @@ fn test_schema_with_generics() {
                                     "200": {
                                         "description": "OK",
                                         "schema": {
-                                            "$ref": "#/definitions/Pet<Dog>",
+                                            "$ref": "#/definitions/Pet%3CDog%3E",
                                         },
                                     },
                                 },


### PR DESCRIPTION
Hi,

Using the latest paperclip release (v0.7.0) I encountered a validation error with schema references.
When using the openapi json in test_app on editor.swagger.io, these kind of messages appears:

_Semantic error at paths./cats.post.parameters.0.schema.$ref
$ref values must be RFC3986-compliant percent-encoded URIs
[Jump to line 59]()_
