### PR TITLE
Fix serde flatten

### DIFF
--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -1148,6 +1148,9 @@ fn handle_unnamed_field_struct(
                         s.description = Some(#docs.to_string());
                     }
                     schema.properties.insert(#inner_field_id.to_string(), s.into());
+                    if #ty_ref::required() {
+                        schema.required.insert(#inner_field_id.to_string());
+                    }
                 })
             } else {
                 quote!({
@@ -1156,11 +1159,11 @@ fn handle_unnamed_field_struct(
                 })
             };
 
-            gen.extend(quote! {
-                if #ty_ref::required() {
-                    schema.required.insert(#inner_field_id.to_string());
-                }
-            });
+            // gen.extend(quote! {
+            //     if #ty_ref::required() {
+            //         schema.required.insert(#inner_field_id.to_string());
+            //     }
+            // });
 
             props_gen.extend(gen);
         }
@@ -1261,6 +1264,10 @@ fn handle_field_struct(
                     s.description = Some(#docs.to_string());
                 }
                 schema.properties.insert(#field_name.into(), s.into());
+
+                if #ty_ref::required() {
+                    schema.required.insert(#field_name.into());
+                }
             })
         } else {
             quote!({
@@ -1269,11 +1276,11 @@ fn handle_field_struct(
             })
         };
 
-        gen.extend(quote! {
-            if #ty_ref::required() {
-                schema.required.insert(#field_name.into());
-            }
-        });
+        // gen.extend(quote! {
+        //     if #ty_ref::required() {
+        //         schema.required.insert(#field_name.into());
+        //     }
+        // });
 
         props_gen.extend(gen);
     }

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -1156,6 +1156,10 @@ fn handle_unnamed_field_struct(
                 quote!({
                     let s = #ty_ref::raw_schema();
                     schema.properties.extend(s.properties);
+
+                    if #ty_ref::required() {
+                        schema.required.extend(s.required);
+                    }
                 })
             };
 
@@ -1273,6 +1277,10 @@ fn handle_field_struct(
             quote!({
                 let s = #ty_ref::raw_schema();
                 schema.properties.extend(s.properties);
+
+                if #ty_ref::required() {
+                    schema.required.extend(s.required);
+                }
             })
         };
 

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -1163,12 +1163,6 @@ fn handle_unnamed_field_struct(
                 })
             };
 
-            // gen.extend(quote! {
-            //     if #ty_ref::required() {
-            //         schema.required.insert(#inner_field_id.to_string());
-            //     }
-            // });
-
             props_gen.extend(gen);
         }
     }
@@ -1283,12 +1277,6 @@ fn handle_field_struct(
                 }
             })
         };
-
-        // gen.extend(quote! {
-        //     if #ty_ref::required() {
-        //         schema.required.insert(#field_name.into());
-        //     }
-        // });
 
         props_gen.extend(gen);
     }

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -1285,7 +1285,7 @@ fn test_serde_flatten() {
         author: Author,
     }
 
-    /// Image to persist
+    /// Article to persist
     #[derive(Deserialize, Apiv2Schema)]
     struct Article {
         description: String,

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -1524,7 +1524,7 @@ fn test_serde_flatten() {
                 json!({
                       "definitions": {
                         "Article": {
-                          "description": "Image to persist",
+                          "description": "Article to persist",
                           "properties": {
                             "address": {
                               "type": "string"


### PR DESCRIPTION
Hi,

When using serde flatten I expect the required fields to match the one described in the definition properties.

This should fix the current behaviour by extending sub struct when flatten is used instead of inserting the current field name for the required fields.