### PR TITLE
Fix missing slash

### DIFF
--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -450,7 +450,11 @@ where
         let mut path_map = BTreeMap::new();
         factory.update_operations(&mut path_map);
         for (path, mut map) in path_map {
-            let p = self.path.clone() + &path;
+            let p = if !self.path.ends_with('/') && !path.starts_with('/') {
+                self.path.clone() + "/" + &path
+            } else {
+                self.path.clone() + &path
+            };
             for op in map.methods.values_mut() {
                 op.set_parameter_names_from_path_template(&p);
             }

--- a/plugins/actix-web/src/web3.rs
+++ b/plugins/actix-web/src/web3.rs
@@ -481,7 +481,11 @@ where
         let mut path_map = BTreeMap::new();
         factory.update_operations(&mut path_map);
         for (path, mut map) in path_map {
-            let p = self.path.clone() + &path;
+            let p = if !self.path.ends_with('/') && !path.starts_with('/') {
+                self.path.clone() + "/" + &path
+            } else {
+                self.path.clone() + &path
+            };
             for op in map.methods.values_mut() {
                 op.set_parameter_names_from_path_template(&p);
             }


### PR DESCRIPTION
When the user does not prefix nor suffix path with a slash, the documentation should build a valid path.
This PR aims to add missing slashes in all part of the url