### PR TITLE
Feat: add example to schema definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.1] - 2022-04-10
+## [Unreleased]
+### Added
+- Add example support for derived `Apiv2Schema`. [PR#421](https://github.com/paperclip-rs/paperclip/pull/421)
+
 ### Fixed
+- Fix missing slashed between url parts [PR#416](https://github.com/paperclip-rs/paperclip/pull/416)
 - Properly support non-BoxBody response payload types [PR#414](https://github.com/paperclip-rs/paperclip/pull/414)
 - Fix required fields definition when using serde flatten [PR#412](https://github.com/paperclip-rs/paperclip/pull/412)
 - Fix reference urls not being RFC3986-compliant [PR#411](https://github.com/paperclip-rs/paperclip/pull/411)

--- a/core/src/v3/schema.rs
+++ b/core/src/v3/schema.rs
@@ -25,11 +25,7 @@ impl From<v2::DefaultSchemaRaw> for openapiv3::ReferenceOr<openapiv3::Schema> {
                         write_only: false,
                         deprecated: false,
                         external_docs: None,
-                        example: if let Some(example) = v2.example {
-                            serde_json::from_str(&example).ok()
-                        } else {
-                            None
-                        },
+                        example: v2.example,
                         title: v2.title,
                         description: v2.description,
                         discriminator: None,

--- a/macros/src/core.rs
+++ b/macros/src/core.rs
@@ -286,7 +286,7 @@ fn schema_fields(name: &Ident, is_ref: bool) -> proc_macro2::TokenStream {
     ));
     gen.extend(quote!(
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub example: Option<String>,
+        pub example: Option<serde_json::Value>,
     ));
 
     gen.extend(quote!(


### PR DESCRIPTION
Add example for schema and fields through openapi attribute. 

This produce valid openapi specification. I changed the example type from `String` to `serde_json::Value` because the specification describe example as 

> A free-form property to include an example of an instance for this schema.

and examples show a json like example value.

This is link to #417 