### PR TITLE
Handle parameters on the format r#type

### DIFF
--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -825,7 +825,7 @@ pub fn emit_v2_definition(input: TokenStream) -> TokenStream {
         ),
     };
 
-    let base_name = extract_rename(&item_ast.attrs).unwrap_or_else(|| name.to_string());
+    let base_name = extract_rename(&item_ast.attrs).unwrap_or_else(|| name.to_string().strip_prefix("r#").map(|s| s.to_string()).unwrap_or(name.to_string()));
     let type_params: Vec<&Ident> = generics.type_params().map(|p| &p.ident).collect();
     let schema_name = if type_params.is_empty() {
         quote! { #base_name }


### PR DESCRIPTION
When you have a struct with  a member using a reserved word as a name, it will be specified as r#type. For Query structs, this is probably quite common. Previously they got hte name "r#type" in the openapi spec, so I just added a strip_prefix r# to handle this case. 