### PR TITLE
Handle parameters on the format r#type

### DIFF
--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -1542,6 +1542,9 @@ fn handle_field_struct(
             .expect("missing field name?")
             .to_string();
 
+        //Strip r# prefix if any
+        field_name = field_name.strip_prefix("r#").map(|n| n.to_string()).unwrap_or(field_name);
+
         if SerdeSkip::exists(&field.attrs) {
             continue;
         }

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -1543,7 +1543,10 @@ fn handle_field_struct(
             .to_string();
 
         //Strip r# prefix if any
-        field_name = field_name.strip_prefix("r#").map(|n| n.to_string()).unwrap_or(field_name);
+        field_name = field_name
+            .strip_prefix("r#")
+            .map(|n| n.to_string())
+            .unwrap_or(field_name);
 
         if SerdeSkip::exists(&field.attrs) {
             continue;

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -4516,6 +4516,22 @@ mod module_path_in_definition_name {
 }
 
 #[test]
+fn test_schema_with_r_literals() {
+    use paperclip::v2::schema::Apiv2Schema;
+    #[derive(paperclip::actix::Apiv2Schema, Deserialize, Serialize)]
+    pub(crate) struct Dog {
+        /// The voice that we love and hate
+        pub(crate) r#bark: String,
+    }
+
+    let dog = Dog::raw_schema();
+    assert_eq!(
+        "bark",
+        dog.properties.iter().next().map(|(k, v)| k).unwrap()
+    );
+}
+
+#[test]
 fn test_schema_with_generics() {
     /// Our non-human family member
     #[derive(Apiv2Schema, Deserialize, Serialize)]


### PR DESCRIPTION
A new version of my previous non working PR, this seems to actually do what I intended.

When you have a struct with a member using a reserved word as a name, it will be specified as r#type. For Query structs, this is probably quite common. Previously they got hte name "r#type" in the openapi spec, so I just added a strip_prefix r# to handle this case.
