### PR TITLE
Clean name from template.

### DIFF
--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -707,7 +707,7 @@ impl<S> Operation<Parameter<S>, Response<S>> {
             .rev()
         {
             if let Some(n) = names.pop() {
-                p.name = n;
+                p.name = n.split_once(':').map(|t| t.0.to_string()).unwrap_or(n);
             } else {
                 break;
             }

--- a/core/tests/test_model.rs
+++ b/core/tests/test_model.rs
@@ -1,0 +1,13 @@
+#[test]
+#[cfg(feature = "v2")]  
+fn test_template_name_with_regex() {
+    use paperclip_core::v2::models::{DefaultParameterRaw, Either, ParameterIn};
+
+    let mut op: paperclip_core::v2::models::DefaultOperationRaw =  Default::default();
+    op.parameters = vec![Either::Right(DefaultParameterRaw{
+        in_: ParameterIn::Path,
+        ..Default::default()
+    })];
+    op.set_parameter_names_from_path_template("/test/{path:.*}");
+    assert_eq!("path", op.parameters.first().unwrap().right().unwrap().name);
+}

--- a/core/tests/test_model.rs
+++ b/core/tests/test_model.rs
@@ -1,10 +1,10 @@
 #[test]
-#[cfg(feature = "v2")]  
+#[cfg(feature = "v2")]
 fn test_template_name_with_regex() {
     use paperclip_core::v2::models::{DefaultParameterRaw, Either, ParameterIn};
 
-    let mut op: paperclip_core::v2::models::DefaultOperationRaw =  Default::default();
-    op.parameters = vec![Either::Right(DefaultParameterRaw{
+    let mut op: paperclip_core::v2::models::DefaultOperationRaw = Default::default();
+    op.parameters = vec![Either::Right(DefaultParameterRaw {
         in_: ParameterIn::Path,
         ..Default::default()
     })];


### PR DESCRIPTION
Avoid including regex from the path template in the name
Fixes: #427