### PR TITLE
Require chrono 0.4

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ actix-web4 = { version = "4", optional = true, default-features = false, package
 actix-multipart = { version = "0", optional = true }
 actix-session = { version = "0", optional = true }
 actix-files = { version = "0", optional = true }
-chrono = { version = "0", optional = true }
+chrono = { version = "0.4", optional = true }
 heck = { version = "0.4", optional = true }
 once_cell = "1.4"
 log = { version = "0.4", optional = true }


### PR DESCRIPTION
With chrono set to require only "0", a project of mine resolved chrono to 0.3 causing things to fail. It is already specified as 0.4 as a dev dependency, so I assume that is what is really intended. 