### PR TITLE
upgrade semver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ log = { version = "0.4", optional = true }
 parking_lot = { version = ">=0.10, <0.13" }
 regex = { version = "1.3", optional = true }
 reqwest = { version = "0.10", features = ["blocking"], optional = true }
-semver = ">=0.9, <0.12"
+semver = "1.0.9"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
semver 1.0 is a much leaner, better crate than it was prior to 1.0. Now
it is stable and will unlikely to see further changes.

We use semver privatly, so this bump is not a semver change for us.