### PR TITLE
Fix apikey authorization

### DIFF
--- a/book/actix-security.md
+++ b/book/actix-security.md
@@ -2,15 +2,16 @@
 
 You can use `Apiv2Security` derive macro for structs which can then be used as handler parameters to have those handlers marked as requiring authorization.
 
+If you need to define a Bearer Authentication :
 ```rust
 use paperclip::actix::Apiv2Security;
 
 #[derive(Apiv2Security)]
 #[openapi(
-  apiKey,
-  in = "header",
-  name = "Authorization",
-  description = "Use format 'Bearer TOKEN'"
+  http,
+  scheme = "bearer",
+  bearer_format = "JWT",
+  description = "Use JWT Bearer token for authentification"
 )]
 pub struct AccessToken;
 
@@ -22,7 +23,28 @@ async fn my_handler(access_token: AccessToken) -> Result<String, MyError> {
 }
 ```
 
-First parameter is the type of security, currently supported types are "apiKey" and "oauth2". Possible parameters are `alias`, `description`, `name`, `in`, `flow`, `auth_url`, `token_url` or `parent`.
+If you need to define an API key Authentication :
+```rust
+use paperclip::actix::Apiv2Security;
+
+#[derive(Apiv2Security)]
+#[openapi(
+  apiKey,
+  in = "header",
+  name = "x-api-key",
+  description = "Use API Key"
+)]
+pub struct AccessToken;
+
+impl FromRequest for Accesstoken { /*...*/ }
+
+#[api_v2_operation]
+async fn my_handler(access_token: AccessToken) -> Result<String, MyError> {
+    /*...*/
+}
+```
+
+First parameter is the type of security, currently supported types are "http", "apiKey" and "oauth2". Possible parameters are `alias`, `description`, `name`, `in`, `bearer_format`, `scheme` `flow`, `auth_url`, `token_url` or `parent`.
 
 Use `alias` parameter if you need to have two different security definitions of the same type.
 

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -323,6 +323,8 @@ pub struct SecurityScheme {
     #[serde(rename = "in", skip_serializing_if = "Option::is_none")]
     pub in_: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme_: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub flow: Option<String>,
     #[serde(rename = "authorizationUrl", skip_serializing_if = "Option::is_none")]
     pub auth_url: Option<String>,

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -347,6 +347,8 @@ impl SecurityScheme {
                 existing.type_ = self.type_;
             }
             existing.in_ = existing.in_.take().or(self.in_);
+            existing.scheme_ = existing.scheme_.take().or(self.scheme_);
+            existing.bearer_format = existing.bearer_format.take().or(self.bearer_format);
             existing.flow = existing.flow.take().or(self.flow);
             existing.auth_url = existing.auth_url.take().or(self.auth_url);
             existing.token_url = existing.token_url.take().or(self.token_url);

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -325,6 +325,8 @@ pub struct SecurityScheme {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scheme_: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub bearer_format: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub flow: Option<String>,
     #[serde(rename = "authorizationUrl", skip_serializing_if = "Option::is_none")]
     pub auth_url: Option<String>,

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -322,8 +322,8 @@ pub struct SecurityScheme {
     pub type_: String,
     #[serde(rename = "in", skip_serializing_if = "Option::is_none")]
     pub in_: Option<String>,
-    #[serde(rename = "scheme", skip_serializing_if = "Option::is_none")]
-    pub scheme_: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bearer_format: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -347,7 +347,7 @@ impl SecurityScheme {
                 existing.type_ = self.type_;
             }
             existing.in_ = existing.in_.take().or(self.in_);
-            existing.scheme_ = existing.scheme_.take().or(self.scheme_);
+            existing.scheme = existing.scheme.take().or(self.scheme);
             existing.bearer_format = existing.bearer_format.take().or(self.bearer_format);
             existing.flow = existing.flow.take().or(self.flow);
             existing.auth_url = existing.auth_url.take().or(self.auth_url);

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -322,7 +322,7 @@ pub struct SecurityScheme {
     pub type_: String,
     #[serde(rename = "in", skip_serializing_if = "Option::is_none")]
     pub in_: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "scheme", skip_serializing_if = "Option::is_none")]
     pub scheme_: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bearer_format: Option<String>,

--- a/core/src/v3/security_scheme.rs
+++ b/core/src/v3/security_scheme.rs
@@ -5,8 +5,8 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
         match v2.type_.as_str() {
             "http" => openapiv3::SecurityScheme::HTTP {
                 scheme: v2.scheme_.unwrap_or("basic".to_string()),
-                bearer_format: v2.scheme_.unwrap_or(None)
-                description: v2.description.unwrap_or(None),
+                bearer_format: v2.scheme_.unwrap_or(None),
+                description: v2.description,
             },
             "apiKey" => {
                 openapiv3::SecurityScheme::APIKey {
@@ -16,7 +16,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                         _ => openapiv3::APIKeyLocation::Query,
                     },
                     name: v2.name.unwrap_or_default(),
-                    description: v2.description.unwrap_or(None),
+                    description: v2.description,
                 }
             }
             "oauth2" => {
@@ -64,7 +64,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                             _ => None,
                         },
                     },
-                    description: v2.description.unwrap_or(None),
+                    description: v2.description,
                 }
             }
             type_ => {

--- a/core/src/v3/security_scheme.rs
+++ b/core/src/v3/security_scheme.rs
@@ -4,7 +4,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
     fn from(v2: v2::SecurityScheme) -> Self {
         match v2.type_.as_str() {
             "http" => openapiv3::SecurityScheme::HTTP {
-                scheme: v2.scheme_.unwrap_or("basic".to_string()),
+                scheme: v2.scheme.unwrap_or("basic".to_string()),
                 bearer_format: v2.bearer_format,
                 description: v2.description,
             },

--- a/core/src/v3/security_scheme.rs
+++ b/core/src/v3/security_scheme.rs
@@ -5,7 +5,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
         match v2.type_.as_str() {
             "http" => openapiv3::SecurityScheme::HTTP {
                 scheme: v2.scheme_.unwrap_or("basic".to_string()),
-                bearer_format: v2.scheme_.unwrap_or(None),
+                bearer_format: v2.bearer_format.unwrap_or_default(),
                 description: v2.description,
             },
             "apiKey" => {

--- a/core/src/v3/security_scheme.rs
+++ b/core/src/v3/security_scheme.rs
@@ -8,17 +8,15 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                 bearer_format: v2.bearer_format,
                 description: v2.description,
             },
-            "apiKey" => {
-                openapiv3::SecurityScheme::APIKey {
-                    location: match v2.in_.unwrap_or_default().as_str() {
-                        "query" => openapiv3::APIKeyLocation::Query,
-                        "header" => openapiv3::APIKeyLocation::Header,
-                        _ => openapiv3::APIKeyLocation::Query,
-                    },
-                    name: v2.name.unwrap_or_default(),
-                    description: v2.description,
-                }
-            }
+            "apiKey" => openapiv3::SecurityScheme::APIKey {
+                location: match v2.in_.unwrap_or_default().as_str() {
+                    "query" => openapiv3::APIKeyLocation::Query,
+                    "header" => openapiv3::APIKeyLocation::Header,
+                    _ => openapiv3::APIKeyLocation::Query,
+                },
+                name: v2.name.unwrap_or_default(),
+                description: v2.description,
+            },
             "oauth2" => {
                 let scopes = v2
                     .scopes

--- a/core/src/v3/security_scheme.rs
+++ b/core/src/v3/security_scheme.rs
@@ -5,7 +5,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
         match v2.type_.as_str() {
             "http" => openapiv3::SecurityScheme::HTTP {
                 scheme: v2.scheme_.unwrap_or("basic".to_string()),
-                bearer_format: v2.bearer_format.unwrap_or_default(),
+                bearer_format: v2.bearer_format,
                 description: v2.description,
             },
             "apiKey" => {

--- a/core/src/v3/security_scheme.rs
+++ b/core/src/v3/security_scheme.rs
@@ -3,29 +3,20 @@ use super::v2;
 impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
     fn from(v2: v2::SecurityScheme) -> Self {
         match v2.type_.as_str() {
-            "basic" => openapiv3::SecurityScheme::HTTP {
-                scheme: "basic".to_string(),
-                bearer_format: None,
-                description: None,
+            "http" => openapiv3::SecurityScheme::HTTP {
+                scheme: v2.scheme_.unwrap_or("basic".to_string()),
+                bearer_format: v2.scheme_.unwrap_or(None)
+                description: v2.description.unwrap_or(None),
             },
             "apiKey" => {
-                // how to determine when it should be JWT?
-                if v2.in_ == Some("header".into()) {
-                    openapiv3::SecurityScheme::HTTP {
-                        scheme: "bearer".to_string(),
-                        bearer_format: Some("JWT".into()),
-                        description: None,
-                    }
-                } else {
-                    openapiv3::SecurityScheme::APIKey {
-                        location: match v2.in_.unwrap_or_default().as_str() {
-                            "query" => openapiv3::APIKeyLocation::Query,
-                            "header" => openapiv3::APIKeyLocation::Header,
-                            _ => openapiv3::APIKeyLocation::Query,
-                        },
-                        name: v2.name.unwrap_or_default(),
-                        description: None,
-                    }
+                openapiv3::SecurityScheme::APIKey {
+                    location: match v2.in_.unwrap_or_default().as_str() {
+                        "query" => openapiv3::APIKeyLocation::Query,
+                        "header" => openapiv3::APIKeyLocation::Header,
+                        _ => openapiv3::APIKeyLocation::Query,
+                    },
+                    name: v2.name.unwrap_or_default(),
+                    description: v2.description.unwrap_or(None),
                 }
             }
             "oauth2" => {
@@ -73,7 +64,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                             _ => None,
                         },
                     },
-                    description: None,
+                    description: v2.description.unwrap_or(None),
                 }
             }
             type_ => {

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -1293,6 +1293,8 @@ pub fn emit_v2_header(input: TokenStream) -> TokenStream {
 
         let docs = (!docs.is_empty()).then(|| docs.to_owned());
         let quoted_description = quote_option(parameter_attrs.get("description").or(docs.as_ref()));
+        let quoted_scheme = quote_option(parameter_attrs.get("scheme"));
+        let quoted_bearer_format = quote_option(parameter_attrs.get("bearer_format"));
         let name_string = field_name.as_ref().map(|name| name.to_string());
         let quoted_name = if let Some(name) = parameter_attrs.get("name").or(name_string.as_ref()) {
             name
@@ -1332,6 +1334,8 @@ pub fn emit_v2_header(input: TokenStream) -> TokenStream {
                 name: #quoted_name.to_owned(),
                 in_: paperclip::v2::models::ParameterIn::Header,
                 description: #quoted_description,
+                scheme: #quoted_scheme,
+                bearer_format: #quoted_bearer_format,
                 data_type: #quoted_type,
                 format: #quoted_format,
                 required: Self::required(),

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -1082,7 +1082,7 @@ pub fn emit_v2_security(input: TokenStream) -> TokenStream {
                         type_: #type_.to_string(),
                         name: #quoted_name,
                         in_: #quoted_in,
-                        scheme_: #quoted_scheme_,
+                        scheme_: #quoted_scheme,
                         bearer_format: #quoted_bearer_format,
                         flow: #quoted_flow,
                         auth_url: #quoted_auth_url,

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -963,7 +963,7 @@ pub fn emit_v2_security(input: TokenStream) -> TokenStream {
         "description",
         "name",
         "in",
-        "scheme_",
+        "scheme",
         "bearer_format",
         "flow",
         "auth_url",
@@ -1082,7 +1082,7 @@ pub fn emit_v2_security(input: TokenStream) -> TokenStream {
                         type_: #type_.to_string(),
                         name: #quoted_name,
                         in_: #quoted_in,
-                        scheme_: #quoted_scheme,
+                        scheme: #quoted_scheme,
                         bearer_format: #quoted_bearer_format,
                         flow: #quoted_flow,
                         auth_url: #quoted_auth_url,
@@ -1293,8 +1293,6 @@ pub fn emit_v2_header(input: TokenStream) -> TokenStream {
 
         let docs = (!docs.is_empty()).then(|| docs.to_owned());
         let quoted_description = quote_option(parameter_attrs.get("description").or(docs.as_ref()));
-        let quoted_scheme = quote_option(parameter_attrs.get("scheme"));
-        let quoted_bearer_format = quote_option(parameter_attrs.get("bearer_format"));
         let name_string = field_name.as_ref().map(|name| name.to_string());
         let quoted_name = if let Some(name) = parameter_attrs.get("name").or(name_string.as_ref()) {
             name
@@ -1334,8 +1332,6 @@ pub fn emit_v2_header(input: TokenStream) -> TokenStream {
                 name: #quoted_name.to_owned(),
                 in_: paperclip::v2::models::ParameterIn::Header,
                 description: #quoted_description,
-                scheme: #quoted_scheme,
-                bearer_format: #quoted_bearer_format,
                 data_type: #quoted_type,
                 format: #quoted_format,
                 required: Self::required(),

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -963,6 +963,8 @@ pub fn emit_v2_security(input: TokenStream) -> TokenStream {
         "description",
         "name",
         "in",
+        "scheme_",
+        "bearer_format",
         "flow",
         "auth_url",
         "token_url",
@@ -1068,6 +1070,8 @@ pub fn emit_v2_security(input: TokenStream) -> TokenStream {
             let quoted_description = quote_option(security_attrs.get("description"));
             let quoted_name = quote_option(security_attrs.get("name"));
             let quoted_in = quote_option(security_attrs.get("in"));
+            let quoted_scheme = quote_option(security_attrs.get("scheme"));
+            let quoted_bearer_format = quote_option(security_attrs.get("bearer_format"));
             let quoted_flow = quote_option(security_attrs.get("flow"));
             let quoted_auth_url = quote_option(security_attrs.get("auth_url"));
             let quoted_token_url = quote_option(security_attrs.get("token_url"));
@@ -1078,6 +1082,8 @@ pub fn emit_v2_security(input: TokenStream) -> TokenStream {
                         type_: #type_.to_string(),
                         name: #quoted_name,
                         in_: #quoted_in,
+                        scheme_: #quoted_scheme_,
+                        bearer_format: #quoted_bearer_format,
                         flow: #quoted_flow,
                         auth_url: #quoted_auth_url,
                         token_url: #quoted_token_url,

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -3376,9 +3376,11 @@ fn test_errors_app() {
 fn test_security_app() {
     #[derive(Apiv2Security, Deserialize)]
     #[openapi(
-        apiKey,
+        http,
         alias = "JWT",
         in = "header",
+        scheme = "bearer",
+        bearer_format = "JWT"
         name = "Authorization",
         description = "Use format 'Bearer TOKEN'"
     )]
@@ -3553,8 +3555,10 @@ fn test_security_app() {
                     "JWT": {
                         "description":"Use format 'Bearer TOKEN'",
                         "in": "header",
+                        "scheme": "bearer",
+                        "bearerFormat": "JWT",
                         "name": "Authorization",
-                        "type": "apiKey"
+                        "type": "http"
                     },
                     "MyOAuth2": {
                         "scopes": {

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -3577,7 +3577,7 @@ fn test_security_app() {
                         ]
                       }
                     },
-                    "/api/echo2": {
+                    "/api/echo3": {
                       "post": {
                         "parameters": [{
                             "in": "body",

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -3376,6 +3376,27 @@ fn test_errors_app() {
 fn test_security_app() {
     #[derive(Apiv2Security, Deserialize)]
     #[openapi(
+        apiKey,
+        alias = "apiKeyToken",
+        in = "header",
+        name = "x-api-key",
+        description = "Use apiKey token"
+    )]
+    struct APIKeyToken;
+
+    impl FromRequest for APIKeyToken {
+        type Error = Error;
+        type Future = Ready<Result<Self, Self::Error>>;
+        #[cfg(not(feature = "actix4"))]
+        type Config = ();
+
+        fn from_request(_: &HttpRequest, _payload: &mut actix_web::dev::Payload) -> Self::Future {
+            ready(Ok(Self {}))
+        }
+    }
+
+    #[derive(Apiv2Security, Deserialize)]
+    #[openapi(
         http,
         alias = "JWT",
         in = "header",
@@ -3443,9 +3464,15 @@ fn test_security_app() {
         body
     }
 
+    #[api_v2_operation]
+    async fn echo_pet_with_apikey(_: APIKeyToken, body: web::Json<Pet>) -> web::Json<Pet> {
+        body
+    }
+
     fn config(cfg: &mut web::ServiceConfig) {
         cfg.service(web::resource("/echo1").route(web::post().to(echo_pet_with_jwt)))
             .service(web::resource("/echo2").route(web::post().to(echo_pet_with_petstore)));
+            .service(web::resource("/echo3").route(web::post().to(echo_pet_with_apikey)));
     }
 
     run_and_check_app(
@@ -3550,6 +3577,31 @@ fn test_security_app() {
                         ]
                       }
                     },
+                    "/api/echo2": {
+                      "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
+                        "responses": {
+                          "200": {
+                            "description": "OK",
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          },
+                        },
+                        "security": [
+                          {
+                            "apiKeyToken": []
+                          }
+                        ]
+                      }
+                    },
                   },
                   "securityDefinitions": {
                     "JWT": {
@@ -3559,6 +3611,12 @@ fn test_security_app() {
                         "bearerFormat": "JWT",
                         "name": "Authorization",
                         "type": "http"
+                    },
+                    "apiKeyToken": {
+                        "description":"Use apiKey token",
+                        "in": "header",
+                        "name": "x-api-key",
+                        "type": "apiKey"
                     },
                     "MyOAuth2": {
                         "scopes": {


### PR DESCRIPTION
I needed to use an Authorization of type `apiKey` in `header`.
But the code that handled that was unreachable due to some conditions to build bearer auth in priority.

According to OAS3 (https://swagger.io/docs/specification/authentication/bearer-authentication/) :
basicAuth should use associations : `type: http` and `scheme: basic`.
bearerAuth should use associations : `type: http`, the `scheme: bearer`and if needed `bearerFormat: JWT`.
ApiKeyAuth should use associations : `type: apiKey`, `in: header` and `name: X-API-KEY`.
cookieAuth should use associations : `type: apiKey`, `in: cookie` and `name: JSESSIONID`.

I adapted the code so we could use all those authentication and fixed the comment standing there :
`// how to determine when it should be JWT?`.

I completed the documentation page and added a test.

![image](https://user-images.githubusercontent.com/49145114/173875005-d886af87-4eba-429f-bb04-a406c83e0b66.png)
![image](https://user-images.githubusercontent.com/49145114/173875078-3bd771af-2ab4-478a-9225-c447838bf61b.png)
