### PR TITLE
fix(deps): Update Uuid dep

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 url = { version = "2", optional = true }
-uuid = { version = "0", optional = true }
+uuid = { version = "1.1", optional = true }
 thiserror = "1.0"
 serde_qs = { version = "0", optional = true }
 actix-web-validator2 = { version = "2.2", optional = true, package = "actix-web-validator" }


### PR DESCRIPTION
Update Uuid dep to prevent the following error when using a more recent version of uuid crate.

note :
I got this error simply while using latest version of uuid dep in an schema :
```rust
#[derive(Apiv2Schema)]
pub struct Pet {
    pub id: Uuid, // Triggered the error
    pub name: String,
}
```
---
![image](https://user-images.githubusercontent.com/49145114/177523733-149e76cf-6d02-4dac-994f-f53983b35a79.png)
