### PR TITLE
Select a release series for uuid which is compatible with diesel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ actix-web3 = { version = "3", default-features = false, package = "actix-web" }
 actix-web4 = { version = "4", default-features = false, package = "actix-web" }
 chrono_dev = { version = "0.4", features = ["serde"], package = "chrono" }
 futures = "0.3"
-uuid_dev = { version = "0.8", features = ["serde"], package = "uuid" }
+uuid_dev = { version = "0.6", features = ["serde"], package = "uuid" }
 reqwest = { version = "0.10", features = ["blocking", "json"] }
 log = { version = "0.4", features = ["kv_unstable"] }
 insta = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 url = { version = "2", optional = true }
-uuid = { version = "0", optional = true }
+uuid = { version = "0.6", optional = true }
 thiserror = "1.0"
 serde_qs = { version = "0", optional = true }
 actix-web-validator2 = { version = "2.2", optional = true, package = "actix-web-validator" }


### PR DESCRIPTION
`uuid = "0"` permits implicit/automatic breaking updates. This version requirement has been the source of many bizarre compilation issues for us, because `paperclip-core` will select `uuid` version 0.8.2, but diesel only provides impls on `uuid` version 0.6.5.

A carefully-manicured `Cargo.lock` can get us out of this situation, but it ends up being a pretty janky developer experience, because any accidental changes to it can often break the build with confusing errors.

The big downside to this is that it puts `paperclip` on `uuid` version 0.6, which in my experience is the only way to make things work with `diesel`. I see that you've previously been using 0.8 (in development?). Is there any particular reason why?