### PR TITLE
feat: Respect `host` setting of v2 spec when converting to v3

### DIFF
--- a/core/src/v3/openapi.rs
+++ b/core/src/v3/openapi.rs
@@ -6,7 +6,7 @@ impl From<v2::DefaultApiRaw> for openapiv3::OpenAPI {
             openapi: "3.0.0".into(),
             tags: v2.tags.iter().cloned().map(From::from).collect(),
             info: v2.info.clone().into(),
-            servers: openapi3_server(v2.host, v2.base_path),
+            servers: openapi3_servers(v2.schemes, v2.host, v2.base_path),
             external_docs: v2.external_docs.map(From::from),
             ..Default::default()
         };
@@ -55,15 +55,41 @@ impl From<v2::DefaultApiRaw> for openapiv3::OpenAPI {
     }
 }
 
-fn openapi3_server(_host: Option<String>, base: Option<String>) -> Vec<openapiv3::Server> {
-    if let Some(base) = base {
+fn openapi3_servers(
+    schemes: std::collections::BTreeSet<v2::OperationProtocol>,
+    host: Option<String>,
+    base: Option<String>,
+) -> Vec<openapiv3::Server> {
+    if schemes.is_empty() && host.is_none() && base.is_none() {
+        vec![]
+    } else if let Some(host) = host {
+        debug_assert!(
+            !schemes.is_empty(),
+            "`schemes` should not be empty when `host` is specified. OpenAPI v3 `servers` cannot be populated."
+        );
+        schemes
+            .into_iter()
+            .map(|scheme| {
+                let scheme_str = match scheme {
+                    v2::OperationProtocol::Http => "http",
+                    v2::OperationProtocol::Https => "https",
+                    v2::OperationProtocol::Ws => "ws",
+                    v2::OperationProtocol::Wss => "wss",
+                };
+                openapiv3::Server {
+                    url: format!("{}://{}{}", scheme_str, host, base.as_deref().unwrap_or("")),
+                    description: None,
+                    variables: None,
+                    extensions: indexmap::IndexMap::new(),
+                }
+            })
+            .collect()
+    } else {
         vec![openapiv3::Server {
-            url: base,
+            url: base.unwrap_or_else(|| "/".to_string()),
             description: None,
             variables: None,
             extensions: indexmap::IndexMap::new(),
         }]
-    } else {
-        vec![]
     }
 }

--- a/core/src/v3/openapi.rs
+++ b/core/src/v3/openapi.rs
@@ -63,27 +63,32 @@ fn openapi3_servers(
     if schemes.is_empty() && host.is_none() && base.is_none() {
         vec![]
     } else if let Some(host) = host {
-        debug_assert!(
-            !schemes.is_empty(),
-            "`schemes` should not be empty when `host` is specified. OpenAPI v3 `servers` cannot be populated."
-        );
-        schemes
-            .into_iter()
-            .map(|scheme| {
-                let scheme_str = match scheme {
-                    v2::OperationProtocol::Http => "http",
-                    v2::OperationProtocol::Https => "https",
-                    v2::OperationProtocol::Ws => "ws",
-                    v2::OperationProtocol::Wss => "wss",
-                };
-                openapiv3::Server {
-                    url: format!("{}://{}{}", scheme_str, host, base.as_deref().unwrap_or("")),
-                    description: None,
-                    variables: None,
-                    extensions: indexmap::IndexMap::new(),
-                }
-            })
-            .collect()
+        if !schemes.is_empty() {
+            schemes
+                .into_iter()
+                .map(|scheme| {
+                    let scheme_str = match scheme {
+                        v2::OperationProtocol::Http => "http",
+                        v2::OperationProtocol::Https => "https",
+                        v2::OperationProtocol::Ws => "ws",
+                        v2::OperationProtocol::Wss => "wss",
+                    };
+                    openapiv3::Server {
+                        url: format!("{}://{}{}", scheme_str, host, base.as_deref().unwrap_or("")),
+                        description: None,
+                        variables: None,
+                        extensions: indexmap::IndexMap::new(),
+                    }
+                })
+                .collect()
+        } else {
+            vec![openapiv3::Server {
+                url: format!("//{}{}", host, base.as_deref().unwrap_or("")),
+                description: None,
+                variables: None,
+                extensions: indexmap::IndexMap::new(),
+            }]
+        }
     } else {
         vec![openapiv3::Server {
             url: base.unwrap_or_else(|| "/".to_string()),


### PR DESCRIPTION
`schemes` and `host` settings used to be completely ignored. This PR properly handles those when populating v3 `servers` field.