### PR TITLE
Move root level extensions to root

### DIFF
--- a/core/src/v3/openapi.rs
+++ b/core/src/v3/openapi.rs
@@ -24,7 +24,7 @@ impl From<v2::DefaultApiRaw> for openapiv3::OpenAPI {
                 i.insert(b.0.to_string(), b.1.clone().into());
                 i
             });
-        components.extensions =
+        spec.extensions =
             v2.extensions
                 .into_iter()
                 .fold(indexmap::IndexMap::new(), |mut i, (k, v)| {


### PR DESCRIPTION
The v2.extensions should be converted to root level extensions in v3 specs, not extensions in the components struct.