### PR TITLE
fix Apiv2Header link in documentation

### DIFF
--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -256,7 +256,7 @@ impl_type_simple!(std::net::Ipv6Addr, DataType::String, DataTypeFormat::IpV6);
 /// for schema objects.
 /// - [`Apiv2Security`](https://paperclip-rs.github.io/paperclip/paperclip_actix/derive.Apiv2Security.html)
 /// for security scheme objects.
-/// - [`Apiv2Header`](https://paperclip-rs.github.io/paperclip/paperclip_actix/derive.Apiv2Security.html)
+/// - [`Apiv2Header`](https://paperclip-rs.github.io/paperclip/paperclip_actix/derive.Apiv2Header.html)
 /// for header parameters objects.
 ///
 /// This is implemented for primitive types by default.


### PR DESCRIPTION
Apiv2Header is currently pointing to [derive.Apiv2Security.html](https://paperclip-rs.github.io/paperclip/paperclip_actix/derive.Apiv2Security.html). I changed it so that it points to [derive.Apiv2Header.html](https://paperclip-rs.github.io/paperclip/paperclip_actix/derive.Apiv2Header.html)