### PR TITLE
Update copyrights to use "Paperclip Contributors"

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2018 Yoshua Wuyts
+   Copyright 2022 Paperclip Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Ravi Shankar
+Copyright (c) 2022 Paperclip Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Addresses issue #390 

Updates the name of the copyright holder in each of the licenses to "Paperclip Contributors"

I wasn't sure if we wanted to change the dates to match? Or if there was a reason the dates on the two licenses were different, so I left that the same. Please let me know if there are any other changes that should be made. This is my first time contributing to this project, so please also let me know if there are any conventions I should have followed that I didn't.  :)