### PR TITLE
Set refresh_url to an empty string

### DIFF
--- a/core/src/v3/security_scheme.rs
+++ b/core/src/v3/security_scheme.rs
@@ -31,14 +31,14 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                         implicit: match flow.as_str() {
                             "implicit" => Some(openapiv3::OAuth2Flow::Implicit {
                                 authorization_url: v2.auth_url.clone().unwrap_or_default(),
-                                refresh_url: None,
+                                refresh_url: Some("".to_string()),
                                 scopes: scopes.clone(),
                             }),
                             _ => None,
                         },
                         password: match flow.as_str() {
                             "password" => Some(openapiv3::OAuth2Flow::Password {
-                                refresh_url: None,
+                                refresh_url: Some("".to_string()),
                                 token_url: v2.token_url.clone().unwrap_or_default(),
                                 scopes: scopes.clone(),
                             }),
@@ -46,7 +46,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                         },
                         client_credentials: match flow.as_str() {
                             "application" => Some(openapiv3::OAuth2Flow::ClientCredentials {
-                                refresh_url: None,
+                                refresh_url: Some("".to_string()),
                                 token_url: v2.token_url.clone().unwrap_or_default(),
                                 scopes: scopes.clone(),
                             }),
@@ -56,7 +56,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                             "accessCode" => Some(openapiv3::OAuth2Flow::AuthorizationCode {
                                 authorization_url: v2.auth_url.clone().unwrap_or_default(),
                                 token_url: v2.token_url.clone().unwrap_or_default(),
-                                refresh_url: None,
+                                refresh_url: Some("".to_string()),
                                 scopes,
                             }),
                             _ => None,


### PR DESCRIPTION
The previous value of refresh_url (None) translated into 'null' in the spec, which is not accepted as a proper value, as refresh_url is supposed to have a string value.

To see an example of how this goes wrong, you can create a spec with the old code (i.e. with refresh_url: None) and paste it into editor.swagger.io. You'll get an error. Now generate a spec using this
new code (i.e. with refresh_url: "") and the error goes away.