### PR TITLE
Use AsyncWriteExt::write_all in ResponseStream::to_writer

### DIFF
--- a/src/build/util_mod.hbs
+++ b/src/build/util_mod.hbs
@@ -33,7 +33,7 @@ impl<T, E> ResponseStream<T, E>
     \{
         while let Some(r) = self.0.next().await \{
             let chunk = r.map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-            writer.write(chunk.as_ref()).await?;
+            writer.write_all(chunk.as_ref()).await?;
         }
 
         Ok(())


### PR DESCRIPTION
Ensures that each chunk is written fully and also silences the clippy lint for 'unused_io_amount' in generated code.

Fixes #490 