### PR TITLE
docs(actix-plugin): bump paperclip version in example

### DIFF
--- a/book/actix-plugin.md
+++ b/book/actix-plugin.md
@@ -16,7 +16,7 @@ actix-web = "4.0"
 # channel (replace "actix4-nightly" feature with "actix4" in that case). There maybe compilation errors,
 # but those can be fixed.
 # Add the "v3" option if you want to expose an OpenAPI v3 document
-paperclip = { version = "0.6", features = ["actix4"] }
+paperclip = { version = "0.8", features = ["actix4"] }
 serde = { version = "1.0", features = ["derive"] }
 ```
 


### PR DESCRIPTION
Ran into the following issue while trying to test paperclip:
```bash
$ actix-paperclip-test git:(main) ✗ cargo build
    Updating crates.io index
error: failed to select a version for `paperclip`.
    ... required by package `actix-paperclip-test v0.1.0 (/Users/maxrn/code/actix-test/actix-paperclip-test)`
versions that meet the requirements `^0.6` are: 0.6.1, 0.6.0

the package `actix-paperclip-test` depends on `paperclip`, with features: `actix4` but `paperclip` does not have these features.


failed to select a version for `paperclip` which could resolve this conflict
```