### PR TITLE
ci: skip clippy::derivable-impls linter for now

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,9 +20,10 @@ jobs:
         include:
           - profile: stable
             experimental: false
+            exclude: -A clippy::derivable-impls
           - profile: nightly
             experimental: true
-            exclude: -A clippy::uninlined-format-args
+            exclude: -A clippy::uninlined-format-args -A clippy::derivable-impls
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
I think stable now pulls in later rust version which leads into this. We should probably consider setting MSRV as AFAIK we don't.