### PR TITLE
fix(path-order): don't trash previous parameter names

### DIFF
--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -568,7 +568,7 @@ macro_rules! impl_path_tuple ({ $($ty:ident),+ } => {
                         description: v.description,
                         collection_format: None, // this defaults to csv
                         items: v.items.as_deref().map(map_schema_to_items),
-                        name: k,
+                        name: String::new(),
                         ..Default::default()
                     }));
                 }

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -726,8 +726,16 @@ impl<S> Operation<Parameter<S>, Response<S>> {
     /// given path template.
     pub fn set_parameter_names_from_path_template(&mut self, path: &str) {
         let mut names = vec![];
-        Api::<(), (), ()>::path_parameters_map(path, |p| {
-            names.push(p.to_owned());
+        Api::<(), (), ()>::path_parameters_map(path, |name| {
+            if self
+                .parameters
+                .iter()
+                .filter(|p| p.in_ == ParameterIn::Path)
+                .all(|p| p.name != name)
+            {
+                names.push(name.to_owned());
+            }
+
             ":".into()
         });
 
@@ -735,6 +743,7 @@ impl<S> Operation<Parameter<S>, Response<S>> {
             .parameters
             .iter_mut()
             .filter(|p| p.in_ == ParameterIn::Path)
+            .filter(|p| p.name.is_empty())
             .rev()
         {
             if let Some(n) = names.pop() {


### PR DESCRIPTION
There's a routine which patches parameter names and it trashes previous attempts when it runs twice.
I'm not sure this is meant to work but it seems that the only time we need this function is when we don't have param names, example:
_p: web::Path<(bool, u32, String)>

We seem to completely ignore param names and just name things from the path, example:
get(ace: web::Path<bool>, user_id: web::Path<u32>, friend: web::Path<String>) This can actually be written as
get(user_id: web::Path<bool>, ace: web::Path<u32>, friend: web::Path<String>)

Which actually swaps parameters in the generate json!!

Resolves: #501 