### PR TITLE
Handle Chrono breaking Change

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,12 +70,12 @@ jobs:
           command: build
           args: --all --features "actix3 cli chrono url uuid swagger-ui rapidoc v3 actix3-validator"
 
-      - name: Build actix2 features
-        uses: actions-rs/cargo@v1
-        timeout-minutes: 10
-        with:
-          command: build
-          args: --all --features "actix2 cli chrono url uuid swagger-ui rapidoc v3"
+      # - name: Build actix2 features
+      #   uses: actions-rs/cargo@v1
+      #   timeout-minutes: 10
+      #   with:
+      #     command: build
+      #     args: --all --features "actix2 cli chrono url uuid swagger-ui rapidoc v3"
 
       - name: Run actix tests
         uses: actions-rs/cargo@v1
@@ -91,12 +91,12 @@ jobs:
           command: test
           args: --all --features "actix3 cli chrono url uuid swagger-ui rapidoc v3 actix3-validator"
 
-      - name: Run actix2 tests
-        uses: actions-rs/cargo@v1
-        timeout-minutes: 20
-        with:
-          command: test
-          args: --all --features "actix2 cli chrono url uuid swagger-ui rapidoc v3"
+      # - name: Run actix2 tests
+      #   uses: actions-rs/cargo@v1
+      #   timeout-minutes: 20
+      #   with:
+      #     command: test
+      #     args: --all --features "actix2 cli chrono url uuid swagger-ui rapidoc v3"
 
       - name: Install cargo-cache
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2023-09-27
+### Fixed
+- Pin openapiv3 to wa breaking change. [PR#508](https://github.com/paperclip-rs/paperclip/pull/508)
+
 ## [0.8.1] - 2023-08-20
 ### Added
 - Add support for `PathBuf` type. [PR#502](https://github.com/paperclip-rs/paperclip/pull/502)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ actix-service1 = { version = "1", package = "actix-service" }
 actix-service2 = { version = "2", package = "actix-service" }
 actix-web-validator2 = { version = "2.2", package = "actix-web-validator" }
 actix-web-validator3 = { version = "3.0", package = "actix-web-validator" }
-actix-web2 = { version = "2", default-features = false, package = "actix-web" }
+#actix-web2 = { version = "2", default-features = false, package = "actix-web" }
 actix-web3 = { version = "3", default-features = false, package = "actix-web" }
 actix-web4 = { version = "4", default-features = false, package = "actix-web" }
 chrono_dev = { version = "0.4", features = ["serde"], package = "chrono" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paperclip"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2018"
 description = "OpenAPI tooling library for type-safe compile-time checked HTTP APIs"
 documentation = "https://paperclip-rs.github.io/paperclip/paperclip"
@@ -17,8 +17,8 @@ path = "src/bin/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-paperclip-actix = { path = "plugins/actix-web", version = "0.6.1", optional = true }
-paperclip-core = { path = "core", version = "0.6.1" }
+paperclip-actix = { path = "plugins/actix-web", version = "0.6.2", optional = true }
+paperclip-core = { path = "core", version = "0.6.2" }
 paperclip-macros = { path = "macros", version = "0.6.3", optional = true }
 
 env_logger = { version = "0.8", optional = true }
@@ -40,7 +40,7 @@ url_dep = { version = ">=1.7,<3", package = "url" }
 thiserror = "1.0"
 anyhow = "1.0"
 once_cell = "1.4"
-openapiv3 = { version = "1.0.2", optional = true }
+openapiv3 = { version = "=1.0.2", optional = true }
 indexmap = { version = "1.0", features = ["serde-1", "std"], optional = true }
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paperclip-core"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2018"
 description = "Core types and traits for paperclip OpenAPI tooling library"
 documentation = "https://paperclip-rs.github.io/paperclip/paperclip_core"
@@ -37,7 +37,7 @@ actix-web-validator2 = { version = "2.2", optional = true, package = "actix-web-
 actix-web-validator3 = { version = "3.0", optional = true, package = "actix-web-validator" }
 validator12 = { version = "0.12", features = ["derive"], optional = true, package = "validator" }
 validator14 = { version = "0.14", features = ["derive"], optional = true, package = "validator" }
-openapiv3 = { version = "1.0.2", optional = true }
+openapiv3 = { version = "=1.0.2", optional = true }
 indexmap = { version = "1.0", features = ["serde-1", "std"], optional = true }
 
 [features]

--- a/plugins/actix-web/Cargo.toml
+++ b/plugins/actix-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paperclip-actix"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2018"
 description = "Paperclip OpenAPI plugin for actix-web framework"
 documentation = "https://paperclip-rs.github.io/paperclip/paperclip_actix"
@@ -9,7 +9,7 @@ homepage = "https://github.com/paperclip-rs/paperclip"
 repository = "https://github.com/paperclip-rs/paperclip"
 
 [dependencies]
-paperclip-core = { path = "../../core", version = "0.6.1", optional = true }
+paperclip-core = { path = "../../core", version = "0.6.2", optional = true }
 paperclip-macros = { path = "../../macros", version = "0.6.3", features = ["actix"] }
 futures = "0.3"
 actix-service1 = { version = "1", package = "actix-service", optional = true }
@@ -20,7 +20,7 @@ actix-web4 = { version = "4", default-features = false, optional = true, package
 mime_guess = { version = "2.0.4", default-features = false }
 serde_json = "1.0"
 once_cell = "1.4"
-openapiv3 = { version = "1.0.2", optional = true }
+openapiv3 = { version = "=1.0.2", optional = true }
 include_dir = { version = "0.7.2", optional = true }
 tinytemplate = { version = "1.1", optional = true }
 

--- a/plugins/actix-web/src/app.rs
+++ b/plugins/actix-web/src/app.rs
@@ -447,7 +447,7 @@ where
         F: Mountable,
     {
         let mut api = self.spec.write().unwrap();
-        api.definitions.extend(factory.definitions().into_iter());
+        api.definitions.extend(factory.definitions());
         SecurityScheme::append_map(
             factory.security_definitions(),
             &mut api.security_definitions,

--- a/plugins/actix-web/src/app3.rs
+++ b/plugins/actix-web/src/app3.rs
@@ -16,7 +16,7 @@ use super::{
     Mountable,
 };
 use actix_service1::ServiceFactory;
-#[cfg(any(feature = "swagger-ui"))]
+#[cfg(feature = "swagger-ui")]
 use actix_web::web::HttpRequest;
 use actix_web::{
     dev::{HttpServiceFactory, MessageBody, ServiceRequest, ServiceResponse, Transform},
@@ -454,7 +454,7 @@ where
         F: Mountable,
     {
         let mut api = self.spec.write().unwrap();
-        api.definitions.extend(factory.definitions().into_iter());
+        api.definitions.extend(factory.definitions());
         SecurityScheme::append_map(
             factory.security_definitions(),
             &mut api.security_definitions,

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -68,10 +68,8 @@ pub trait Mountable {
     fn update_operations(&mut self, map: &mut BTreeMap<String, DefaultPathItemRaw>) {
         let operations = self.operations();
         if !operations.is_empty() {
-            let op_map = map
-                .entry(self.path().into())
-                .or_insert_with(Default::default);
-            op_map.methods.extend(operations.into_iter());
+            let op_map = map.entry(self.path().into()).or_default();
+            op_map.methods.extend(operations);
         }
     }
 }

--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -121,8 +121,8 @@ where
     /// Wrapper for [`actix_web::Resource::route`](https://docs.rs/actix-web/*/actix_web/struct.Resource.html#method.route).
     pub fn route(mut self, route: Route) -> Self {
         let w = RouteWrapper::from(&self.path, route);
-        self.operations.extend(w.operations.into_iter());
-        self.definitions.extend(w.definitions.into_iter());
+        self.operations.extend(w.operations);
+        self.definitions.extend(w.definitions);
         SecurityScheme::append_map(w.security, &mut self.security);
         self.inner = self.inner.route(w.inner);
         self
@@ -248,7 +248,7 @@ where
                 self.operations.insert(method.into(), op.clone());
             }
 
-            self.definitions.extend(U::definitions().into_iter());
+            self.definitions.extend(U::definitions());
             SecurityScheme::append_map(U::security_definitions(), &mut self.security);
         }
     }
@@ -444,7 +444,7 @@ where
     where
         M: Mountable,
     {
-        self.definitions.extend(factory.definitions().into_iter());
+        self.definitions.extend(factory.definitions());
         let mut path_map = BTreeMap::new();
         factory.update_operations(&mut path_map);
         for (path, mut map) in path_map {
@@ -488,8 +488,8 @@ impl<T> Mountable for Scope<T> {
 
     fn update_operations(&mut self, map: &mut BTreeMap<String, DefaultPathItemRaw>) {
         for (path, item) in mem::take(&mut self.path_map) {
-            let op_map = map.entry(path).or_insert_with(Default::default);
-            op_map.methods.extend(item.methods.into_iter());
+            let op_map = map.entry(path).or_default();
+            op_map.methods.extend(item.methods);
         }
     }
 }
@@ -719,8 +719,8 @@ impl<'a> Mountable for ServiceConfig<'a> {
 
     fn update_operations(&mut self, map: &mut BTreeMap<String, DefaultPathItemRaw>) {
         for (path, item) in mem::take(&mut self.path_map) {
-            let op_map = map.entry(path).or_insert_with(Default::default);
-            op_map.methods.extend(item.methods.into_iter());
+            let op_map = map.entry(path).or_default();
+            op_map.methods.extend(item.methods);
         }
     }
 }
@@ -729,7 +729,7 @@ impl<'a> ServiceConfig<'a> {
     /// Wrapper for [`actix_web::web::ServiceConfig::route`](https://docs.rs/actix-web/*/actix_web/web/struct.ServiceConfig.html#method.route).
     pub fn route(&mut self, path: &str, route: Route) -> &mut Self {
         let mut w = RouteWrapper::from(path, route);
-        self.definitions.extend(w.definitions().into_iter());
+        self.definitions.extend(w.definitions());
         w.update_operations(&mut self.path_map);
         SecurityScheme::append_map(w.security, &mut self.security);
         self.inner.route(path, w.inner);
@@ -741,7 +741,7 @@ impl<'a> ServiceConfig<'a> {
     where
         F: Mountable + HttpServiceFactory + 'static,
     {
-        self.definitions.extend(factory.definitions().into_iter());
+        self.definitions.extend(factory.definitions());
         factory.update_operations(&mut self.path_map);
         SecurityScheme::append_map(factory.security_definitions(), &mut self.security);
         self.inner.service(factory);

--- a/plugins/actix-web/src/web3.rs
+++ b/plugins/actix-web/src/web3.rs
@@ -138,8 +138,8 @@ where
     /// Wrapper for [`actix_web::Resource::route`](https://docs.rs/actix-web/*/actix_web/struct.Resource.html#method.route).
     pub fn route(mut self, route: Route) -> Self {
         let w = RouteWrapper::from(&self.path, route);
-        self.operations.extend(w.operations.into_iter());
-        self.definitions.extend(w.definitions.into_iter());
+        self.operations.extend(w.operations);
+        self.definitions.extend(w.definitions);
         SecurityScheme::append_map(w.security, &mut self.security);
         self.inner = self.inner.route(w.inner);
         self
@@ -271,7 +271,7 @@ where
                 self.operations.insert(method.into(), op.clone());
             }
 
-            self.definitions.extend(U::definitions().into_iter());
+            self.definitions.extend(U::definitions());
             SecurityScheme::append_map(U::security_definitions(), &mut self.security);
         }
     }
@@ -479,7 +479,7 @@ where
     where
         M: Mountable,
     {
-        self.definitions.extend(factory.definitions().into_iter());
+        self.definitions.extend(factory.definitions());
         let mut path_map = BTreeMap::new();
         factory.update_operations(&mut path_map);
         for (path, mut map) in path_map {
@@ -523,8 +523,8 @@ impl<T> Mountable for Scope<T> {
 
     fn update_operations(&mut self, map: &mut BTreeMap<String, DefaultPathItemRaw>) {
         for (path, item) in mem::take(&mut self.path_map) {
-            let op_map = map.entry(path).or_insert_with(Default::default);
-            op_map.methods.extend(item.methods.into_iter());
+            let op_map = map.entry(path).or_default();
+            op_map.methods.extend(item.methods);
         }
     }
 }
@@ -752,8 +752,8 @@ impl<'a> Mountable for ServiceConfig<'a> {
 
     fn update_operations(&mut self, map: &mut BTreeMap<String, DefaultPathItemRaw>) {
         for (path, item) in mem::take(&mut self.path_map) {
-            let op_map = map.entry(path).or_insert_with(Default::default);
-            op_map.methods.extend(item.methods.into_iter());
+            let op_map = map.entry(path).or_default();
+            op_map.methods.extend(item.methods);
         }
     }
 }
@@ -762,7 +762,7 @@ impl<'a> ServiceConfig<'a> {
     /// Wrapper for [`actix_web::web::ServiceConfig::route`](https://docs.rs/actix-web/*/actix_web/web/struct.ServiceConfig.html#method.route).
     pub fn route(&mut self, path: &str, route: Route) -> &mut Self {
         let mut w = RouteWrapper::from(path, route);
-        self.definitions.extend(w.definitions().into_iter());
+        self.definitions.extend(w.definitions());
         w.update_operations(&mut self.path_map);
         SecurityScheme::append_map(w.security, &mut self.security);
         self.inner.route(path, w.inner);
@@ -774,7 +774,7 @@ impl<'a> ServiceConfig<'a> {
     where
         F: Mountable + HttpServiceFactory + 'static,
     {
-        self.definitions.extend(factory.definitions().into_iter());
+        self.definitions.extend(factory.definitions());
         factory.update_operations(&mut self.path_map);
         SecurityScheme::append_map(factory.security_definitions(), &mut self.security);
         self.inner.service(factory);

--- a/src/v2/codegen/emitter.rs
+++ b/src/v2/codegen/emitter.rs
@@ -423,7 +423,7 @@ where
         let mut mods = state.mod_children.borrow_mut();
         for (i, path) in rel_path.ancestors().enumerate() {
             if let (Some(parent), Some(name)) = (path.parent(), path.file_name()) {
-                let entry = mods.entry(parent.into()).or_insert_with(HashSet::new);
+                let entry = mods.entry(parent.into()).or_default();
                 entry.insert(ChildModule {
                     name: name.to_string_lossy().into_owned(),
                     is_final: i == 0,
@@ -973,7 +973,7 @@ where
         let ops = obj[0] // first object is always the globally defined object.
             .paths
             .entry(self.path.into())
-            .or_insert_with(Default::default);
+            .or_default();
 
         let mut response_contains_any = false;
         let response_ty_path = if let Some(s) = Self::get_2xx_response_schema(op) {
@@ -1093,7 +1093,7 @@ where
         let ops = obj[0] // first object is always the globally defined object.
             .paths
             .entry(self.path.into())
-            .or_insert_with(Default::default);
+            .or_default();
 
         ops.req.insert(
             meth,


### PR DESCRIPTION
    ci(actix-2): disable tests
    
    chrono 0.4.30 included a breaking change with the Duration:
    https://github.com/chronotope/chrono/releases/tag/v0.4.30
    This only affects actix2 actix-http 1, so simply disable its
    CI for now since it's unlikely anyone is still using it anyways and
    we should probably remove support for this in the future.
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    ci(clippy): remove useless conversions and more
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>