### PR TITLE
add lint ignores to paperclip unit struct

### DIFF
--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -44,7 +44,10 @@ pub fn emit_v2_operation(attrs: TokenStream, input: TokenStream) -> TokenStream 
     let unit_struct = Ident::new(&s_name, default_span);
     let generics = &item_ast.sig.generics;
     let mut generics_call = quote!();
-    let mut struct_definition = quote!(struct #unit_struct;);
+    let mut struct_definition = quote!(
+        #[allow(non_camel_case_types, missing_docs)]
+        struct #unit_struct;
+    );
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     if !generics.params.is_empty() {
         let turbofish = ty_generics.as_turbofish();


### PR DESCRIPTION
Code generated from the `api_v2_operation` proc macro includes a unit struct definition of the form `paperclip_snake_case_struct_name` and was trigging the non-camel-case type name lint. Added the same lint ignores here as are used on the other struct definition in the same macro. 