### PR TITLE
build: update openapiv3 to v2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ url_dep = { version = ">=1.7,<3", package = "url" }
 thiserror = "1.0"
 anyhow = "1.0"
 once_cell = "1.4"
-openapiv3 = { version = "1.0.3", optional = true }
+openapiv3-paper = { version = "2.0", optional = true }
 
 [dev-dependencies]
 actix-rt1 = { version = "1.0", package = "actix-rt" }
@@ -82,7 +82,7 @@ cli = ["env_logger", "structopt", "git2", "v2", "codegen"]
 codegen = ["heck", "http", "log", "regex", "tinytemplate", "paperclip-core/codegen"]
 v2 = ["paperclip-macros/v2", "paperclip-core/v2"]
 # OpenAPI v2 to v3 support
-v3 = ["openapiv3", "v2", "paperclip-core/v3", "paperclip-actix/v3"]
+v3 = ["openapiv3-paper", "v2", "paperclip-core/v3", "paperclip-actix/v3"]
 
 
 # Features for implementing traits for dependencies.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,7 +38,7 @@ actix-web-validator2 = { version = "2.2", optional = true, package = "actix-web-
 actix-web-validator3 = { version = "3.0", optional = true, package = "actix-web-validator" }
 validator12 = { version = "0.12", features = ["derive"], optional = true, package = "validator" }
 validator14 = { version = "0.14", features = ["derive"], optional = true, package = "validator" }
-openapiv3 = { version = "1.0.3", optional = true }
+openapiv3-paper = { version = "2.0", optional = true }
 
 [features]
 # actix-web support
@@ -55,7 +55,7 @@ nightly = ["paperclip-macros/nightly"]
 
 # OpenAPI support (v2 and codegen)
 v2 = ["paperclip-macros/v2"]
-v3 = ["v2", "openapiv3"]
+v3 = ["v2", "openapiv3-paper"]
 codegen = ["v2", "heck", "log"]
 uuid = ["uuid0"]
 uuid0 = ["uuid0_dep"]

--- a/core/src/v3/operation.rs
+++ b/core/src/v3/operation.rs
@@ -125,6 +125,7 @@ impl From<v2::Operation<v2::DefaultParameterRaw, v2::DefaultResponseRaw>> for op
             },
             servers: vec![],
             extensions: Default::default(),
+            callbacks: Default::default(),
         }
     }
 }

--- a/core/src/v3/parameter.rs
+++ b/core/src/v3/parameter.rs
@@ -128,7 +128,9 @@ pub(crate) fn non_body_parameter_to_v3_parameter(
                         max_length: v2.max_length.map(|v| v as usize),
                     }))
                 }
-                v2::DataType::Boolean => openapiv3::SchemaKind::Type(openapiv3::Type::Boolean {}),
+                v2::DataType::Boolean => {
+                    openapiv3::SchemaKind::Type(openapiv3::Type::Boolean(Default::default()))
+                }
                 v2::DataType::Array => {
                     openapiv3::SchemaKind::Type(openapiv3::Type::Array(openapiv3::ArrayType {
                         items: v2.items.as_ref().map(|items| items.clone().into()),

--- a/core/src/v3/schema.rs
+++ b/core/src/v3/schema.rs
@@ -167,7 +167,9 @@ fn v2_data_type_to_v3(
                 max_length: None,
             }))
         }
-        v2::DataType::Boolean => openapiv3::SchemaKind::Type(openapiv3::Type::Boolean {}),
+        v2::DataType::Boolean => {
+            openapiv3::SchemaKind::Type(openapiv3::Type::Boolean(Default::default()))
+        }
         v2::DataType::Array => {
             openapiv3::SchemaKind::Type(openapiv3::Type::Array(openapiv3::ArrayType {
                 items: items.as_ref().map(|items| items.deref().clone().into()),
@@ -332,7 +334,9 @@ impl From<v2::Items> for openapiv3::ReferenceOr<Box<openapiv3::Schema>> {
                         max_length: v2.max_length.map(|v| v as usize),
                     }))
                 }
-                v2::DataType::Boolean => openapiv3::SchemaKind::Type(openapiv3::Type::Boolean {}),
+                v2::DataType::Boolean => {
+                    openapiv3::SchemaKind::Type(openapiv3::Type::Boolean(Default::default()))
+                }
                 v2::DataType::Array => {
                     openapiv3::SchemaKind::Type(openapiv3::Type::Array(openapiv3::ArrayType {
                         items: v2.items.map(|items| items.deref().clone().into()),

--- a/core/src/v3/security_scheme.rs
+++ b/core/src/v3/security_scheme.rs
@@ -16,6 +16,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                 scheme: "basic".to_string(),
                 bearer_format: None,
                 description: v2.description,
+                extensions: Default::default(),
             },
             "apiKey" => openapiv3::SecurityScheme::APIKey {
                 location: match v2.in_.unwrap_or_default().as_str() {
@@ -25,46 +26,53 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                 },
                 name: v2.name.unwrap_or_default(),
                 description: v2.description,
+                extensions: Default::default(),
             },
             "oauth2" => {
                 let flow = v2.flow.unwrap_or_default();
                 openapiv3::SecurityScheme::OAuth2 {
                     flows: openapiv3::OAuth2Flows {
                         implicit: match flow.as_str() {
-                            "implicit" => Some(openapiv3::OAuth2Flow::Implicit {
+                            "implicit" => Some(openapiv3::ImplicitOAuth2Flow {
                                 authorization_url: v2.auth_url.clone().unwrap_or_default(),
                                 refresh_url: None,
                                 scopes: to_indexmap!(v2),
+                                extensions: Default::default(),
                             }),
                             _ => None,
                         },
                         password: match flow.as_str() {
-                            "password" => Some(openapiv3::OAuth2Flow::Password {
+                            "password" => Some(openapiv3::PasswordOAuth2Flow {
                                 refresh_url: None,
                                 token_url: v2.token_url.clone().unwrap_or_default(),
                                 scopes: to_indexmap!(v2),
+                                extensions: Default::default(),
                             }),
                             _ => None,
                         },
                         client_credentials: match flow.as_str() {
-                            "application" => Some(openapiv3::OAuth2Flow::ClientCredentials {
+                            "application" => Some(openapiv3::ClientCredentialsOAuth2Flow {
                                 refresh_url: None,
                                 token_url: v2.token_url.clone().unwrap_or_default(),
                                 scopes: to_indexmap!(v2),
+                                extensions: Default::default(),
                             }),
                             _ => None,
                         },
                         authorization_code: match flow.as_str() {
-                            "accessCode" => Some(openapiv3::OAuth2Flow::AuthorizationCode {
+                            "accessCode" => Some(openapiv3::AuthorizationCodeOAuth2Flow {
                                 authorization_url: v2.auth_url.clone().unwrap_or_default(),
                                 token_url: v2.token_url.clone().unwrap_or_default(),
                                 refresh_url: None,
                                 scopes: to_indexmap!(v2),
+                                extensions: Default::default(),
                             }),
                             _ => None,
                         },
+                        extensions: Default::default(),
                     },
                     description: v2.description,
+                    extensions: Default::default(),
                 }
             }
             type_ => {
@@ -73,6 +81,7 @@ impl From<v2::SecurityScheme> for openapiv3::SecurityScheme {
                     scheme: "invalid".to_string(),
                     bearer_format: None,
                     description: v2.description,
+                    extensions: Default::default(),
                 }
             }
         }

--- a/plugins/actix-web/Cargo.toml
+++ b/plugins/actix-web/Cargo.toml
@@ -20,7 +20,7 @@ actix-web4 = { version = "4", default-features = false, optional = true, package
 mime_guess = { version = "2.0.4", default-features = false }
 serde_json = "1.0"
 once_cell = "1.4"
-openapiv3 = { version = "1.0.3", optional = true }
+openapiv3-paper = { version = "2.0", optional = true }
 include_dir = { version = "0.7.2", optional = true }
 tinytemplate = { version = "1.1", optional = true }
 
@@ -30,6 +30,6 @@ actix3 = ["actix-web3", "actix-service1", "paperclip-core/actix3"]
 actix4 = ["actix-web4", "actix-service2", "paperclip-core/actix4"]
 nightly = ["paperclip-core/nightly"]
 normalize = []
-v3 = ["openapiv3", "paperclip-core/v3"]
+v3 = ["openapiv3-paper", "paperclip-core/v3"]
 swagger-ui = ["include_dir"]
 rapidoc = ["tinytemplate", "include_dir"]


### PR DESCRIPTION
There's a breaking change on the crate which does not expose the fields as pub and so we need to use our own patch for now.