### PR TITLE
fix maps in v2->v3 schema conversion

### DIFF
--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -4672,6 +4672,7 @@ where
     ret
 }
 
+#[track_caller]
 fn check_json(resp: reqwest::blocking::Response, expected: serde_json::Value) {
     assert_eq!(resp.status().as_u16(), 200);
     let json = resp.json::<serde_json::Value>().expect("json error");


### PR DESCRIPTION
Maps were previously appearing as `fieldname: object` with no schema definitions added for the value types in the map. This PR adds the map value type as an additional property on the relevant V3 schema for the parent struct field.