### PR TITLE
Fix: tests

### DIFF
--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -31,9 +31,10 @@ static PATH_TEMPLATE_REGEX: Lazy<Regex> =
 const SPECIAL_HEADERS: &[&str] = &["content-type", "accept", "authorization"];
 
 /// OpenAPI version.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Version {
     #[serde(rename = "2.0")]
+    #[default]
     V2,
 }
 
@@ -253,8 +254,9 @@ pub struct Api<P, R, S> {
 }
 
 /// The format used by spec (JSON/YAML).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum SpecFormat {
+    #[default]
     Json,
     Yaml,
 }
@@ -664,20 +666,22 @@ where
 }
 
 /// The location of the parameter.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "camelCase")]
 pub enum ParameterIn {
     Query,
     Header,
     Path,
     FormData,
+    #[default]
     Body,
 }
 
 /// Possible formats for array values in parameter.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 pub enum CollectionFormat {
+    #[default]
     Csv,
     Ssv,
     Tsv,
@@ -939,14 +943,6 @@ where
     }
 }
 
-/* Common trait impls */
-
-impl Default for SpecFormat {
-    fn default() -> Self {
-        SpecFormat::Json
-    }
-}
-
 #[cfg(feature = "actix-base")]
 impl From<&Method> for HttpMethod {
     fn from(method: &Method) -> HttpMethod {
@@ -1029,25 +1025,6 @@ impl<S> Clone for Resolvable<S> {
 impl Display for HttpMethod {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl Default for Version {
-    fn default() -> Self {
-        Version::V2
-    }
-}
-
-impl Default for CollectionFormat {
-    fn default() -> Self {
-        CollectionFormat::Csv
-    }
-}
-
-/// **NOTE:** This is just a stub. This is usually set explicitly.
-impl Default for ParameterIn {
-    fn default() -> Self {
-        ParameterIn::Body
     }
 }
 

--- a/src/build/cli_util.hbs
+++ b/src/build/cli_util.hbs
@@ -51,7 +51,7 @@ where
 
     match resp \{
         Ok(r) => Ok(r),
-        Err(ApiError::Failure(_, _, r)) => Ok(r.into_inner()),
+        Err(ApiError::Failure(_, _, r)) => Ok(r),
         Err(e) => return Err(e.into()),
     }
 }


### PR DESCRIPTION
The current 'make test' encounters some errors during execution.

The first commit addresses only the clippy [warnings](https://rust-lang.github.io/rust-clippy/master/index.html#/derivable_impls).

The second commit, [fix: Fix test, extract response on client error](https://github.com/paperclip-rs/paperclip/commit/6c141b5b46905d05bc1626e7afe4340af00c7f35), resolves the following error:

```
error[E0599]: no method named `into_inner` found for associated type `<C as ApiClient>::Response` in the current scope
  --> ./cli.rs:74:49
   |
74 |         Err(ApiError::Failure(_, _, r)) => Ok(r.into_inner()),
   |                                                 ^^^^^^^^^^ method not found in `<C as ApiClient>::Response`

```

Could someone confirm if this commit is the aproach to resolve the issue?