### PR TITLE
Change proc-macro-error dependency to proc-macro-error2 in macros

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 [dependencies]
 mime = "0.3"
 proc-macro2 = "1.0"
-proc-macro-error = "1.0"
+proc-macro-error2 = "2.0.1"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 heck = { version = "0.4", optional = true }

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -5,7 +5,6 @@ use heck::*;
 use http::StatusCode;
 use lazy_static::lazy_static;
 use proc_macro::TokenStream;
-use proc_macro_error::ResultExt;
 use quote::{quote, ToTokens};
 use strum_macros::EnumString;
 use syn::{
@@ -769,7 +768,9 @@ fn field_extract_f32(nv: MetaNameValue) -> Option<proc_macro2::TokenStream> {
         },
         Lit::Float(f) => Ok(quote! { #f }),
         Lit::Int(i) => {
-            let f: f32 = i.base10_parse().unwrap_or_abort();
+            let f: f32 = i
+                .base10_parse()
+                .unwrap_or_else(|e| abort!(i.span(), "{}", e));
             Ok(quote! { #f })
         }
         _ => {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,7 +7,7 @@
 
 extern crate proc_macro;
 #[macro_use]
-extern crate proc_macro_error;
+extern crate proc_macro_error2;
 
 #[cfg(feature = "actix")]
 #[macro_use]


### PR DESCRIPTION
This PR updates the `proc-macro-error` dependency to `proc-macro-error2` in the macros package. The change includes:

1. In `macros/Cargo.toml`:
   - Changed `proc-macro-error = "1.0"` to `proc-macro-error2 = "2.0.1"`

2. In `macros/src/actix.rs`:
   - Removed the import of `ResultExt` from `proc_macro_error`
   - Updated the error handling in the `Lit::Int` match arm to use `abort!` macro instead of `unwrap_or_abort()`

3. In `macros/src/lib.rs`:
   - Changed the external crate declaration from `proc_macro_error` to `proc_macro_error2`

Closes https://github.com/paperclip-rs/paperclip/issues/544