### PR TITLE
fix: bump paperclip-macros minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.1] - 2024-09-10
+## [0.9.2] - 2024-10-13
+### Fixed
+- Switch to pro-macro-error2. [PR#545](https://github.com/paperclip-rs/paperclip/pull/545)
+- Bumps paperclip-macros to 0.7.0 to fix breaking change in 0.6.4. [PR#546](https://github.com/paperclip-rs/paperclip/pull/546)
+
+## [0.9.1] - 2024-09-10 [ YANKED ]
 ### Fixed
 - Support array field type. [PR#531](https://github.com/paperclip-rs/paperclip/pull/531)
 
-## [0.9.0] - 2024-09-07
+## [0.9.0] - 2024-09-07 [ YANKED ]
 ### Fixed
 - Support latest openapiv3 and indexmap. [PR#507](https://github.com/paperclip-rs/paperclip/pull/507)
 - Clippy useless vec lint. [PR#511](https://github.com/paperclip-rs/paperclip/pull/511)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paperclip"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2018"
 description = "OpenAPI tooling library for type-safe compile-time checked HTTP APIs"
 documentation = "https://paperclip-rs.github.io/paperclip/paperclip"
@@ -17,9 +17,9 @@ path = "src/bin/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-paperclip-actix = { path = "plugins/actix-web", version = "0.7.1", optional = true }
-paperclip-core = { path = "core", version = "0.7.1" }
-paperclip-macros = { path = "macros", version = "0.6.5", optional = true }
+paperclip-actix = { path = "plugins/actix-web", version = "0.7.2", optional = true }
+paperclip-core = { path = "core", version = "0.7.2" }
+paperclip-macros = { path = "macros", version = "0.7.0", optional = true }
 
 env_logger = { version = "0.8", optional = true }
 git2 = { version = "0.15", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paperclip-core"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2018"
 description = "Core types and traits for paperclip OpenAPI tooling library"
 documentation = "https://paperclip-rs.github.io/paperclip/paperclip_core"
@@ -9,7 +9,7 @@ homepage = "https://github.com/paperclip-rs/paperclip"
 repository = "https://github.com/paperclip-rs/paperclip"
 
 [dependencies]
-paperclip-macros = { path = "../macros", version = "0.6.5" }
+paperclip-macros = { path = "../macros", version = "0.7.0" }
 actix-web2 = { version = "2", optional = true, default-features = false, package = "actix-web" }
 actix-web3 = { version = "3", optional = true, default-features = false, package = "actix-web" }
 actix-web4 = { version = "4", optional = true, default-features = false, package = "actix-web" }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paperclip-macros"
-version = "0.6.5"
+version = "0.7.0"
 edition = "2018"
 description = "Macros for paperclip OpenAPI tooling library"
 documentation = "https://paperclip-rs.github.io/paperclip/paperclip_macros"

--- a/plugins/actix-web/Cargo.toml
+++ b/plugins/actix-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paperclip-actix"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2018"
 description = "Paperclip OpenAPI plugin for actix-web framework"
 documentation = "https://paperclip-rs.github.io/paperclip/paperclip_actix"
@@ -9,8 +9,8 @@ homepage = "https://github.com/paperclip-rs/paperclip"
 repository = "https://github.com/paperclip-rs/paperclip"
 
 [dependencies]
-paperclip-core = { path = "../../core", version = "0.7.1", optional = true }
-paperclip-macros = { path = "../../macros", version = "0.6.5", features = ["actix"] }
+paperclip-core = { path = "../../core", version = "0.7.2", optional = true }
+paperclip-macros = { path = "../../macros", version = "0.7.0", features = ["actix"] }
 futures = "0.3"
 actix-service1 = { version = "1", package = "actix-service", optional = true }
 actix-service2 = { version = "2", package = "actix-service", optional = true }


### PR DESCRIPTION
This is to address min/max being added and breaking back compat. paperclip-macros 0.6.4 and 0.6.5 will be yanked from crates. paperclip 0.9.0 and 0.9.1 will also be yanked from crates.

Resolves #542 