### PR TITLE
Support jiff 0.2

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,7 @@ actix-session = { version = "0", optional = true }
 actix-identity = { version = "0", optional = true }
 actix-files = { version = "0", optional = true }
 chrono = { version = "0.4", optional = true }
-jiff = { version = "0.1.5", optional = true }
+jiff = { version = "<0.3", optional = true }
 heck = { version = "0.4", optional = true }
 once_cell = "1.4"
 log = { version = "0.4", optional = true }


### PR DESCRIPTION
We can support jiff 02 with no code changes, so this patch only loosen up the version requirements